### PR TITLE
Feat#8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.env
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,43 +1,45 @@
 plugins {
-	java
 	id("org.springframework.boot") version "3.4.4"
-	id("io.spring.dependency-management") version "1.1.7"
+	id("io.spring.dependency-management") version "1.1.4"
+	kotlin("jvm") version "1.9.22"
+	kotlin("plugin.spring") version "1.9.22"
+	kotlin("plugin.jpa") version "1.9.22"
 }
 
 group = "com.dolpin"
 version = "0.0.1-SNAPSHOT"
-
-java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
-}
-
-configurations {
-	compileOnly {
-		extendsFrom(configurations.annotationProcessor.get())
-	}
-}
+java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
 	mavenCentral()
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	implementation("org.springframework.boot:spring-boot-starter-data-redis")
-	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
-	implementation("org.springframework.boot:spring-boot-starter-security")
-	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("org.springframework.security:spring-security-oauth2-client")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+	// JWT
+	implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+
+	// Database
+	implementation("org.postgresql:postgresql")
+	implementation("org.hibernate.orm:hibernate-spatial")
+
+	// Lombok (Java 코드용)
 	compileOnly("org.projectlombok:lombok")
-	runtimeOnly("org.postgresql:postgresql")
-	implementation("org.hibernate.orm:hibernate-spatial:6.6.11.Final")
-	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 	annotationProcessor("org.projectlombok:lombok")
+
+	// 테스트
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	//환경변수
+	implementation("me.paulschwarz:spring-dotenv:3.0.0")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/dolpin/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dolpin/domain/auth/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.dolpin.domain.auth.controller;
+
+import com.dolpin.domain.auth.dto.response.OAuthUrlResponse;
+import com.dolpin.domain.auth.service.auth.AuthService;
+import com.dolpin.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/oauth")
+    public ResponseEntity<ApiResponse<OAuthUrlResponse>> getOAuthLoginUrl(
+            @RequestParam(defaultValue = "kakao") String provider) {
+        try {
+            OAuthUrlResponse response = authService.getOAuthLoginUrl(provider);
+            return ResponseEntity.ok(ApiResponse.success("success", response));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("지원하지 않는 OAuth 제공자입니다: " + provider));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("서버 내부 오류입니다."));
+        }
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dolpin/domain/auth/controller/AuthController.java
@@ -1,16 +1,20 @@
 package com.dolpin.domain.auth.controller;
 
+import com.dolpin.domain.auth.dto.request.TokenRequest;
 import com.dolpin.domain.auth.dto.response.OAuthUrlResponse;
+import com.dolpin.domain.auth.dto.response.RefreshTokenResponse;
+import com.dolpin.domain.auth.dto.response.TokenResponse;
 import com.dolpin.domain.auth.service.auth.AuthService;
+import com.dolpin.global.exception.BusinessException;
 import com.dolpin.global.response.ApiResponse;
 import com.dolpin.global.response.ResponseStatus;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -31,18 +35,79 @@ public class AuthController {
         ));
     }
 
-    @GetMapping("/tokens")
-    public ResponseEntity<ApiResponse<String>> getToken(@RequestParam String code) {
-        log.info("Received authorization code: {}", code);
+    // POST로만 처리하도록 변경 (프론트엔드에서 인증 코드를 백엔드에 전달)
+    @PostMapping("/tokens")
+    public ResponseEntity<ApiResponse<TokenResponse>> getTokens(
+            @RequestBody TokenRequest request,
+            HttpServletResponse response) {
+        log.info("Authorization code received in POST request: {}", request.getAuthorizationCode());
+        TokenResponse tokenResponse = authService.generateTokenByAuthorizationCode(request.getAuthorizationCode());
 
-        // 개발 초기 단계에서 간단한 응답 반환
+        // 리프레시 토큰을 쿠키에 설정
+        addRefreshTokenCookie(response, tokenResponse.getRefreshToken());
+
+        // 응답에서 리프레시 토큰 제거 (보안)
+        TokenResponse responseWithoutRefreshToken = TokenResponse.builder()
+                .accessToken(tokenResponse.getAccessToken())
+                .tokenType(tokenResponse.getTokenType())
+                .expiresIn(tokenResponse.getExpiresIn())
+                .user(tokenResponse.getUser())
+                .build();
+
         return ResponseEntity.ok(ApiResponse.success(
-                ResponseStatus.SUCCESS.withMessage("로그인 성공"),
-                "코드: " + code + " (토큰 발급 로직 구현 예정)"
+                "login_success",
+                responseWithoutRefreshToken
         ));
+    }
 
-        // 실제 구현 시에는 다음과 같이 서비스 메서드 호출
-        // TokenResponse tokenResponse = authService.getToken(code);
-        // return ResponseEntity.ok(ApiResponse.success(ResponseStatus.SUCCESS, tokenResponse));
+    @PostMapping("/token/refresh")
+    public ResponseEntity<ApiResponse<RefreshTokenResponse>> refreshToken(
+            @CookieValue(name = "refresh_token", required = false) String refreshToken) {
+
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new BusinessException(ResponseStatus.UNAUTHORIZED.withMessage("리프레시 토큰이 없습니다."));
+        }
+
+        log.info("Refresh token received from cookie");
+        RefreshTokenResponse response = authService.refreshToken(refreshToken);
+        return ResponseEntity.ok(ApiResponse.success(
+                "token_refresh_success",
+                response
+        ));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @CookieValue(name = "refresh_token", required = false) String refreshToken,
+            HttpServletResponse response) {
+
+        if (refreshToken != null && !refreshToken.isEmpty()) {
+            log.info("Logout requested with refresh token from cookie");
+            authService.logout(refreshToken);
+        }
+
+        // 리프레시 토큰 쿠키 삭제
+        deleteRefreshTokenCookie(response);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.success("logout_success", null));
+    }
+
+    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie("refresh_token", refreshToken);
+        cookie.setHttpOnly(true);  // JavaScript에서 접근 불가
+        cookie.setSecure(true);    // HTTPS에서만 전송
+        cookie.setPath("/");       // 모든 경로에서 접근 가능
+        cookie.setMaxAge(14 * 24 * 60 * 60);  // 14일 유효
+        response.addCookie(cookie);
+    }
+
+    private void deleteRefreshTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("refresh_token", null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);  // 즉시 만료
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/com/dolpin/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dolpin/domain/auth/controller/AuthController.java
@@ -1,7 +1,6 @@
 package com.dolpin.domain.auth.controller;
 
 import com.dolpin.domain.auth.dto.response.OAuthUrlResponse;
-import com.dolpin.domain.auth.dto.response.TokenResponse;
 import com.dolpin.domain.auth.service.auth.AuthService;
 import com.dolpin.global.response.ApiResponse;
 import com.dolpin.global.response.ResponseStatus;

--- a/src/main/java/com/dolpin/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dolpin/domain/auth/controller/AuthController.java
@@ -1,9 +1,12 @@
 package com.dolpin.domain.auth.controller;
 
 import com.dolpin.domain.auth.dto.response.OAuthUrlResponse;
+import com.dolpin.domain.auth.dto.response.TokenResponse;
 import com.dolpin.domain.auth.service.auth.AuthService;
 import com.dolpin.global.response.ApiResponse;
+import com.dolpin.global.response.ResponseStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
+@Slf4j
 public class AuthController {
 
     private final AuthService authService;
@@ -20,16 +24,26 @@ public class AuthController {
     @GetMapping("/oauth")
     public ResponseEntity<ApiResponse<OAuthUrlResponse>> getOAuthLoginUrl(
             @RequestParam(defaultValue = "kakao") String provider) {
-        try {
-            OAuthUrlResponse response = authService.getOAuthLoginUrl(provider);
-            return ResponseEntity.ok(ApiResponse.success("success", response));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest()
-                    .body(ApiResponse.error("지원하지 않는 OAuth 제공자입니다: " + provider));
-        } catch (Exception e) {
-            e.printStackTrace();
-            return ResponseEntity.internalServerError()
-                    .body(ApiResponse.error("서버 내부 오류입니다."));
-        }
+        log.info("oauthProvider : {}", provider);
+        OAuthUrlResponse response = authService.getOAuthLoginUrl(provider);
+        return ResponseEntity.ok(ApiResponse.success(
+                ResponseStatus.SUCCESS.withMessage("소셜 로그인 URL 조회에 성공하였습니다."),
+                response
+        ));
+    }
+
+    @GetMapping("/tokens")
+    public ResponseEntity<ApiResponse<String>> getToken(@RequestParam String code) {
+        log.info("Received authorization code: {}", code);
+
+        // 개발 초기 단계에서 간단한 응답 반환
+        return ResponseEntity.ok(ApiResponse.success(
+                ResponseStatus.SUCCESS.withMessage("로그인 성공"),
+                "코드: " + code + " (토큰 발급 로직 구현 예정)"
+        ));
+
+        // 실제 구현 시에는 다음과 같이 서비스 메서드 호출
+        // TokenResponse tokenResponse = authService.getToken(code);
+        // return ResponseEntity.ok(ApiResponse.success(ResponseStatus.SUCCESS, tokenResponse));
     }
 }

--- a/src/main/java/com/dolpin/domain/auth/dto/request/TokenRequest.java
+++ b/src/main/java/com/dolpin/domain/auth/dto/request/TokenRequest.java
@@ -1,0 +1,12 @@
+package com.dolpin.domain.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRequest {
+    private String authorizationCode;
+}

--- a/src/main/java/com/dolpin/domain/auth/dto/response/OAuthUrlResponse.java
+++ b/src/main/java/com/dolpin/domain/auth/dto/response/OAuthUrlResponse.java
@@ -1,0 +1,12 @@
+package com.dolpin.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OAuthUrlResponse {
+    private String redirect_url;
+}

--- a/src/main/java/com/dolpin/domain/auth/dto/response/RefreshTokenResponse.java
+++ b/src/main/java/com/dolpin/domain/auth/dto/response/RefreshTokenResponse.java
@@ -1,0 +1,15 @@
+package com.dolpin.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenResponse {
+    private String newAccessToken;
+    private Long expiresIn;
+}

--- a/src/main/java/com/dolpin/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/dolpin/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,49 @@
+package com.dolpin.domain.auth.dto.response;
+
+import com.dolpin.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType;
+    private Long expiresIn;
+    private UserInfo user;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserInfo {
+        private Long id;
+        private String username;
+        private String profileImageUrl;
+        private String provider;
+
+        public static UserInfo from(User user) {
+            return UserInfo.builder()
+                    .id(user.getId())
+                    .username(user.getUsername())
+                    .profileImageUrl(user.getImageUrl())
+                    .provider(user.getProvider())
+                    .build();
+        }
+    }
+
+    public static TokenResponse of(String accessToken, Long expiresIn, String refreshToken, String tokenType, User user) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType(tokenType)
+                .expiresIn(expiresIn)
+                .user(UserInfo.from(user))
+                .build();
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/entity/Token.java
+++ b/src/main/java/com/dolpin/domain/auth/entity/Token.java
@@ -1,0 +1,69 @@
+package com.dolpin.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import com.dolpin.domain.auth.entity.enums.TokenStatus;
+import com.dolpin.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_token")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Token {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(length = 10, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TokenStatus status;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    @Column(nullable = false)
+    private boolean isRevoked;
+
+    /**
+     * 토큰이 만료되었는지 확인
+     */
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiredAt) || isRevoked;
+    }
+
+    /**
+     * 토큰 무효화 처리
+     */
+    public void revoke() {
+        this.isRevoked = true;
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/entity/enums/OAuthProvider.java
+++ b/src/main/java/com/dolpin/domain/auth/entity/enums/OAuthProvider.java
@@ -1,0 +1,22 @@
+package com.dolpin.domain.auth.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthProvider {
+    KAKAO("kakao"),
+    GOOGLE("google");
+
+    private final String name;
+
+    public static OAuthProvider fromString(String provider) {
+        return Arrays.stream(OAuthProvider.values())
+                .filter(p -> p.getName().equalsIgnoreCase(provider))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown OAuth provider: " + provider));
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/entity/enums/TokenStatus.java
+++ b/src/main/java/com/dolpin/domain/auth/entity/enums/TokenStatus.java
@@ -1,0 +1,7 @@
+package com.dolpin.domain.auth.entity.enums;
+
+public enum TokenStatus {
+    ACTIVE,
+    EXPIRED,
+    REVOKED
+}

--- a/src/main/java/com/dolpin/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/dolpin/domain/auth/repository/TokenRepository.java
@@ -1,0 +1,21 @@
+package com.dolpin.domain.auth.repository;
+
+import com.dolpin.domain.auth.entity.Token;
+import com.dolpin.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByToken(String token);
+    List<Token> findAllByUser(User user);
+    void deleteAllByUser(User user);
+
+    @Query("SELECT t FROM Token t WHERE t.user.id = :userId AND t.isRevoked = false AND t.expiredAt > CURRENT_TIMESTAMP")
+    List<Token> findValidTokensByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/dolpin/domain/auth/service/auth/AuthService.java
+++ b/src/main/java/com/dolpin/domain/auth/service/auth/AuthService.java
@@ -1,8 +1,12 @@
 package com.dolpin.domain.auth.service.auth;
 
 import com.dolpin.domain.auth.dto.response.OAuthUrlResponse;
+import com.dolpin.domain.auth.dto.response.TokenResponse;
+import com.dolpin.domain.auth.dto.response.RefreshTokenResponse;
 
 public interface AuthService {
-
     OAuthUrlResponse getOAuthLoginUrl(String provider);
+    TokenResponse generateTokenByAuthorizationCode(String code);
+    RefreshTokenResponse refreshToken(String refreshToken);
+    void logout(String refreshToken);
 }

--- a/src/main/java/com/dolpin/domain/auth/service/auth/AuthService.java
+++ b/src/main/java/com/dolpin/domain/auth/service/auth/AuthService.java
@@ -1,0 +1,8 @@
+package com.dolpin.domain.auth.service.auth;
+
+import com.dolpin.domain.auth.dto.response.OAuthUrlResponse;
+
+public interface AuthService {
+
+    OAuthUrlResponse getOAuthLoginUrl(String provider);
+}

--- a/src/main/java/com/dolpin/domain/auth/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/dolpin/domain/auth/service/auth/AuthServiceImpl.java
@@ -1,22 +1,121 @@
 package com.dolpin.domain.auth.service.auth;
 
 import com.dolpin.domain.auth.dto.response.OAuthUrlResponse;
+import com.dolpin.domain.auth.dto.response.RefreshTokenResponse;
+import com.dolpin.domain.auth.dto.response.TokenResponse;
+import com.dolpin.domain.auth.entity.Token;
 import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+import com.dolpin.domain.auth.service.oauth.OAuthApiClient;
+import com.dolpin.domain.auth.service.oauth.OAuthInfoResponse;
+import com.dolpin.domain.auth.service.oauth.OAuthLoginParams;
 import com.dolpin.domain.auth.service.oauth.OAuthLoginUrlProvider;
 import com.dolpin.domain.auth.service.oauth.OAuthLoginUrlProviderFactory;
+import com.dolpin.domain.auth.service.oauth.kakao.KakaoLoginParams;
+import com.dolpin.domain.auth.service.token.JwtTokenProvider;
+import com.dolpin.domain.auth.service.token.TokenService;
+import com.dolpin.domain.user.entity.User;
+import com.dolpin.domain.user.service.UserCommandService;
+import com.dolpin.domain.user.service.UserQueryService;
+import com.dolpin.global.exception.BusinessException;
+import com.dolpin.global.response.ResponseStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
 @Service
-@RequiredArgsConstructor
+@RequiredArgsConstructor // Lombok이 모든 final 필드를 포함하는 생성자를 생성합니다
 public class AuthServiceImpl implements AuthService {
 
     private final OAuthLoginUrlProviderFactory oAuthLoginUrlProviderFactory;
+    private final List<OAuthApiClient> oAuthApiClients; // Map 대신 List로 선언
+    private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
+    private final TokenService tokenService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public OAuthUrlResponse getOAuthLoginUrl(String provider) {
         OAuthProvider oAuthProvider = OAuthProvider.fromString(provider);
         OAuthLoginUrlProvider urlProvider = oAuthLoginUrlProviderFactory.getProvider(oAuthProvider);
         return new OAuthUrlResponse(urlProvider.getLoginUrl());
+    }
+
+    @Override
+    @Transactional
+    public TokenResponse generateTokenByAuthorizationCode(String code) {
+        // 임시적으로 Kakao로 설정 (향후 제공자 감지 로직 추가 필요)
+        OAuthProvider provider = OAuthProvider.KAKAO;
+
+        // 주입받은 List에서 필요한 ApiClient 찾기
+        OAuthApiClient apiClient = oAuthApiClients.stream()
+                .filter(client -> client.oauthProvider() == provider)
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ResponseStatus.OAUTH_PROVIDER_NOT_EXIST));
+
+        // 1. 인증 코드로 OAuth 액세스 토큰 요청
+        OAuthLoginParams loginParams = createLoginParams(code, provider);
+        String oauthAccessToken = apiClient.requestAccessToken(loginParams);
+
+        if (oauthAccessToken == null || oauthAccessToken.isEmpty()) {
+            throw new BusinessException(ResponseStatus.UNAUTHORIZED.withMessage("OAuth 인증에 실패했습니다."));
+        }
+
+        // 2. OAuth 액세스 토큰으로 사용자 정보 요청
+        OAuthInfoResponse userInfo = apiClient.requestUserInfo(oauthAccessToken);
+
+        // 3. 사용자 정보로 회원 찾기 또는 새로 생성
+        User user = findOrCreateUser(userInfo);
+
+        // 4. JWT 토큰 생성 (액세스 토큰)
+        String accessToken = jwtTokenProvider.generateToken(user.getId());
+
+        // 5. 리프레시 토큰 생성 및 저장
+        Token refreshToken = tokenService.createRefreshToken(user);
+
+        // 6. 토큰 응답 생성 및 반환
+        return TokenResponse.of(
+                accessToken,
+                jwtTokenProvider.getExpirationMs() / 1000,
+                refreshToken.getToken(),
+                "Bearer",
+                user
+        );
+    }
+
+    @Override
+    @Transactional
+    public RefreshTokenResponse refreshToken(String refreshToken) {
+        return tokenService.refreshAccessToken(refreshToken);
+    }
+
+    @Override
+    @Transactional
+    public void logout(String refreshToken) {
+        tokenService.invalidateRefreshToken(refreshToken);
+    }
+
+    // 사용자 찾기 또는 생성 (내부 메서드)
+    private User findOrCreateUser(OAuthInfoResponse userInfo) {
+        Optional<User> userOptional = userQueryService.findByProviderAndProviderId(
+                userInfo.getProvider(),
+                Long.parseLong(userInfo.getProviderId())
+        );
+
+        return userOptional.orElseGet(() -> userCommandService.createUser(userInfo));
+    }
+
+    // OAuth 로그인 파라미터 생성 (내부 메서드)
+    private OAuthLoginParams createLoginParams(String code, OAuthProvider provider) {
+        // Kakao 전용 구현 (향후 확장 필요)
+        if (provider == OAuthProvider.KAKAO) {
+            return new KakaoLoginParams(code, null);
+        }
+
+        throw new BusinessException(ResponseStatus.OAUTH_PROVIDER_NOT_EXIST);
     }
 }

--- a/src/main/java/com/dolpin/domain/auth/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/dolpin/domain/auth/service/auth/AuthServiceImpl.java
@@ -1,0 +1,22 @@
+package com.dolpin.domain.auth.service.auth;
+
+import com.dolpin.domain.auth.dto.response.OAuthUrlResponse;
+import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+import com.dolpin.domain.auth.service.oauth.OAuthLoginUrlProvider;
+import com.dolpin.domain.auth.service.oauth.OAuthLoginUrlProviderFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final OAuthLoginUrlProviderFactory oAuthLoginUrlProviderFactory;
+
+    @Override
+    public OAuthUrlResponse getOAuthLoginUrl(String provider) {
+        OAuthProvider oAuthProvider = OAuthProvider.fromString(provider);
+        OAuthLoginUrlProvider urlProvider = oAuthLoginUrlProviderFactory.getProvider(oAuthProvider);
+        return new OAuthUrlResponse(urlProvider.getLoginUrl());
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthApiClient.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthApiClient.java
@@ -1,0 +1,13 @@
+package com.dolpin.domain.auth.service.oauth;
+
+import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+
+public interface OAuthApiClient {
+    // 토큰 발급 요청
+    String requestAccessToken(OAuthLoginParams params);
+
+    // 사용자 정보 요청
+    OAuthInfoResponse requestUserInfo(String accessToken);
+
+    OAuthProvider oauthProvider();
+}

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthInfoResponse.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthInfoResponse.java
@@ -1,0 +1,10 @@
+package com.dolpin.domain.auth.service.oauth;
+
+
+public interface OAuthInfoResponse {
+    String getProviderId();
+    String getEmail();
+    String getNickname();
+    String getProfileImageUrl();
+    String getProvider();
+}

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthLoginParams.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthLoginParams.java
@@ -10,4 +10,5 @@ public interface OAuthLoginParams {
     OAuthProvider oauthProvider();
     MultiValueMap<String, String> makeBody();
     String getAuthorizationCode();
+    String getRedirectUri();
 }

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthLoginParams.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthLoginParams.java
@@ -1,0 +1,13 @@
+package com.dolpin.domain.auth.service.oauth;
+
+import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * OAuth 로그인에 필요한 파라미터
+ */
+public interface OAuthLoginParams {
+    OAuthProvider oauthProvider();
+    MultiValueMap<String, String> makeBody();
+    String getAuthorizationCode();
+}

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthLoginUrlProvider.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthLoginUrlProvider.java
@@ -1,0 +1,11 @@
+package com.dolpin.domain.auth.service.oauth;
+
+import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+
+/**
+ * OAuth 로그인 URL 제공자 인터페이스
+ */
+public interface OAuthLoginUrlProvider {
+    String getLoginUrl();
+    OAuthProvider getOAuthProvider();
+}

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthLoginUrlProviderFactory.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthLoginUrlProviderFactory.java
@@ -1,0 +1,21 @@
+package com.dolpin.domain.auth.service.oauth;
+
+import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthLoginUrlProviderFactory {
+
+    private final List<OAuthLoginUrlProvider> providers;
+
+    public OAuthLoginUrlProvider getProvider(OAuthProvider provider) {
+        return providers.stream()
+                .filter(p -> p.getOAuthProvider() == provider)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 OAuth 제공자입니다: " + provider.getName())); //customexception 만들면 수정해야함
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthLoginUrlProviderFactory.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/OAuthLoginUrlProviderFactory.java
@@ -1,6 +1,7 @@
 package com.dolpin.domain.auth.service.oauth;
 
 import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+import com.dolpin.global.exception.auth.OAuthProviderNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,6 @@ public class OAuthLoginUrlProviderFactory {
         return providers.stream()
                 .filter(p -> p.getOAuthProvider() == provider)
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 OAuth 제공자입니다: " + provider.getName())); //customexception 만들면 수정해야함
+                .orElseThrow(() -> new OAuthProviderNotFoundException(provider.getName()));
     }
 }

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/kakao/KakaoApiClient.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/kakao/KakaoApiClient.java
@@ -1,0 +1,91 @@
+package com.dolpin.domain.auth.service.oauth.kakao;
+
+import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+import com.dolpin.domain.auth.service.oauth.OAuthApiClient;
+import com.dolpin.domain.auth.service.oauth.OAuthLoginParams;
+import com.dolpin.domain.auth.service.oauth.OAuthInfoResponse;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Kakao OAuth API Client
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class KakaoApiClient implements OAuthApiClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${kakao.oauth.authorization-uri}")
+    private String authorizationUri;
+
+    @Value("${kakao.oauth.client-id}")
+    private String clientId;
+
+    @Value("${kakao.oauth.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.oauth.api-url:https://kapi.kakao.com}")
+    private String apiUrl;
+
+    @Override
+    public OAuthProvider oauthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+
+    @Override
+    public String requestAccessToken(OAuthLoginParams loginParams) {
+        String tokenUrl = authorizationUri.replace("/oauth/authorize", "/oauth/token");
+        log.info("Requesting Kakao AccessToken from URL: {}", tokenUrl);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = loginParams.makeBody();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", loginParams.getAuthorizationCode());
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        KakaoTokenResponse response = restTemplate.postForObject(tokenUrl, request, KakaoTokenResponse.class);
+        return (response != null) ? response.getAccessToken() : null;
+    }
+
+    @Override
+    public OAuthInfoResponse requestUserInfo(String accessToken) {
+        String url = apiUrl + "/v2/user/me";
+        log.info("Requesting Kakao UserInfo from URL: {}", url);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setBearerAuth(accessToken);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("property_keys", "[\"kakao_account.email\",\"kakao_account.profile\"]");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        return restTemplate.postForObject(url, request, KakaoInfoResponse.class);
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class KakaoTokenResponse {
+        @JsonProperty("access_token")
+        private String accessToken;
+
+        public String getAccessToken() {
+            return accessToken;
+        }
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/kakao/KakaoInfoResponse.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/kakao/KakaoInfoResponse.java
@@ -1,0 +1,59 @@
+package com.dolpin.domain.auth.service.oauth.kakao;
+
+import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+import com.dolpin.domain.auth.service.oauth.OAuthInfoResponse;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoInfoResponse implements OAuthInfoResponse {
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoAccount {
+        private String email;
+        private Profile profile;
+
+        @Getter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        static class Profile {
+            private String nickname;
+
+            @JsonProperty("profile_image_url")
+            private String profileImageUrl;
+        }
+    }
+
+    @Override
+    public String getProviderId() {
+        return id.toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount.email;
+    }
+
+    @Override
+    public String getNickname() {
+        return kakaoAccount.profile.nickname;
+    }
+
+    @Override
+    public String getProfileImageUrl() {
+        return kakaoAccount.profile.profileImageUrl;
+    }
+
+    @Override
+    public String getProvider() {
+        return OAuthProvider.KAKAO.getName();
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/kakao/KakaoLoginParams.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/kakao/KakaoLoginParams.java
@@ -1,0 +1,30 @@
+package com.dolpin.domain.auth.service.oauth.kakao;
+
+import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+import com.dolpin.domain.auth.service.oauth.OAuthLoginParams;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KakaoLoginParams implements OAuthLoginParams {
+
+    private String authorizationCode;
+    private String redirectUri;
+
+    @Override
+    public OAuthProvider oauthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+
+    @Override
+    public MultiValueMap<String, String> makeBody() {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        return body;
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/kakao/KakaoLoginParams.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/kakao/KakaoLoginParams.java
@@ -2,19 +2,25 @@ package com.dolpin.domain.auth.service.oauth.kakao;
 
 import com.dolpin.domain.auth.entity.enums.OAuthProvider;
 import com.dolpin.domain.auth.service.oauth.OAuthLoginParams;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-@Getter
-@Setter
-@NoArgsConstructor
-public class KakaoLoginParams implements OAuthLoginParams {
+import java.util.Objects;
 
-    private String authorizationCode;
-    private String redirectUri;
+
+@Getter
+public class KakaoLoginParams implements OAuthLoginParams {
+    private final String authorizationCode;
+    private final String redirectUri;
+
+    @Builder
+    public KakaoLoginParams(String authorizationCode, String redirectUri) {
+        // 유효성 검증 추가
+        this.authorizationCode = Objects.requireNonNull(authorizationCode, "인증 코드는 필수입니다");
+        this.redirectUri = redirectUri;
+    }
 
     @Override
     public OAuthProvider oauthProvider() {
@@ -25,6 +31,12 @@ public class KakaoLoginParams implements OAuthLoginParams {
     public MultiValueMap<String, String> makeBody() {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("code", authorizationCode);
+
+        // redirectUri가 있을 때만 추가
+        if (redirectUri != null && !redirectUri.isEmpty()) {
+            body.add("redirect_uri", redirectUri);
+        }
+
         return body;
     }
 }

--- a/src/main/java/com/dolpin/domain/auth/service/oauth/kakao/KakaoLoginUrlProvider.java
+++ b/src/main/java/com/dolpin/domain/auth/service/oauth/kakao/KakaoLoginUrlProvider.java
@@ -1,0 +1,32 @@
+package com.dolpin.domain.auth.service.oauth.kakao;
+
+import com.dolpin.domain.auth.entity.enums.OAuthProvider;
+import com.dolpin.domain.auth.service.oauth.OAuthLoginUrlProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoLoginUrlProvider implements OAuthLoginUrlProvider {
+
+    @Value("${kakao.oauth.client-id}")
+    private String clientId;
+
+    @Value("${kakao.oauth.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.oauth.authorization-uri}")
+    private String authorizationUri;
+
+    @Override
+    public String getLoginUrl() {
+        return authorizationUri +
+                "?client_id=" + clientId +
+                "&redirect_uri=" + redirectUri +
+                "&response_type=code";
+    }
+
+    @Override
+    public OAuthProvider getOAuthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/service/token/JwtTokenProvider.java
+++ b/src/main/java/com/dolpin/domain/auth/service/token/JwtTokenProvider.java
@@ -1,0 +1,81 @@
+package com.dolpin.domain.auth.service.token;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret:dolpinsecretkey}")
+    private String secretKey;
+
+    @Value("${jwt.expiration:3600000}")
+    private long expirationMs; // 기본값 1시간
+
+    private SecretKey key; // Key 대신 SecretKey 사용
+
+    @PostConstruct
+    public void init() {
+        try {
+            // 비밀키가 최소 32바이트(256비트) 이상이 되도록 보장
+            if (secretKey.length() < 32) {
+                secretKey = String.format("%-32s", secretKey).replace(' ', 'x');
+                log.warn("JWT secret key is too short. It has been padded to at least 32 bytes.");
+            }
+            // SecretKey로 변환
+            this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+            log.info("JWT token provider initialized");
+        } catch (Exception e) {
+            log.error("JWT token provider initialization failed: {}", e.getMessage(), e);
+            throw new RuntimeException("JWT token provider initialization failed", e);
+        }
+    }
+
+    public String generateToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+                .subject(userId.toString())
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(key) // 이제 SecretKey로 정상 동작할 것입니다
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(key) // 이제 SecretKey로 정상 동작할 것입니다
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            log.error("JWT token validation error: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public long getExpirationMs() {
+        return expirationMs;
+    }
+}

--- a/src/main/java/com/dolpin/domain/auth/service/token/TokenService.java
+++ b/src/main/java/com/dolpin/domain/auth/service/token/TokenService.java
@@ -1,0 +1,94 @@
+package com.dolpin.domain.auth.service.token;
+
+import com.dolpin.domain.auth.entity.Token;
+import com.dolpin.domain.auth.entity.enums.TokenStatus;
+import com.dolpin.domain.auth.repository.TokenRepository;
+import com.dolpin.domain.auth.dto.response.RefreshTokenResponse;
+import com.dolpin.domain.user.entity.User;
+import com.dolpin.global.exception.BusinessException;
+import com.dolpin.global.response.ResponseStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final TokenRepository tokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public Token createRefreshToken(User user) {
+        // 기존 리프레시 토큰 무효화
+        invalidateUserTokens(user);
+
+        // 새 리프레시 토큰 생성
+        String refreshToken = jwtTokenProvider.generateToken(user.getId());
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiryDate = now.plusDays(14); // 리프레시 토큰 유효기간 2주
+
+        Token token = Token.builder()
+                .user(user)
+                .token(refreshToken)
+                .status(TokenStatus.ACTIVE)
+                .createdAt(now)
+                .expiredAt(expiryDate)
+                .isRevoked(false)
+                .build();
+
+        return tokenRepository.save(token);
+    }
+
+    @Transactional
+    public void invalidateUserTokens(User user) {
+        List<Token> userTokens = tokenRepository.findAllByUser(user);
+        userTokens.forEach(Token::revoke);
+        tokenRepository.saveAll(userTokens);
+    }
+
+    @Transactional
+    public RefreshTokenResponse refreshAccessToken(String refreshToken) {
+        // 리프레시 토큰 조회
+        Token token = tokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new BusinessException(
+                        ResponseStatus.UNAUTHORIZED.withMessage("리프레시 토큰이 유효하지 않습니다.")));
+
+        // 만료 또는 취소된 토큰 체크
+        if (token.isExpired()) {
+            throw new BusinessException(
+                    ResponseStatus.UNAUTHORIZED.withMessage("리프레시 토큰이 만료되었습니다."));
+        }
+
+        // 새 액세스 토큰 생성
+        String newAccessToken = jwtTokenProvider.generateToken(token.getUser().getId());
+
+        return RefreshTokenResponse.builder()
+                .newAccessToken(newAccessToken)
+                .expiresIn(jwtTokenProvider.getExpirationMs() / 1000)
+                .build();
+    }
+
+    @Transactional
+    public void invalidateRefreshToken(String refreshToken) {
+        Token token = tokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new BusinessException(
+                        ResponseStatus.UNAUTHORIZED.withMessage("리프레시 토큰이 유효하지 않습니다.")));
+
+        token.revoke();
+        tokenRepository.save(token);
+        log.info("Refresh token invalidated for user: {}", token.getUser().getId());
+    }
+
+    @Transactional(readOnly = true)
+    public boolean validateRefreshToken(String refreshToken) {
+        return tokenRepository.findByToken(refreshToken)
+                .map(token -> !token.isExpired())
+                .orElse(false);
+    }
+}

--- a/src/main/java/com/dolpin/domain/user/entity/User.java
+++ b/src/main/java/com/dolpin/domain/user/entity/User.java
@@ -1,77 +1,84 @@
 package com.dolpin.domain.user.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
+import lombok.*;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "provider_id", nullable = false, unique = true)
+    @Column(nullable = false)
     private Long providerId;
 
-    @Column(name = "provider", nullable = false, length = 10)
+    @Column(length = 10, nullable = false)
     private String provider;
 
-    @Column(name = "image_url", length = 255)
-    private String imageUrl;
-
-    @Column(name = "introduction", length = 70)
-    private String introduction;
-
-    @Column(name = "username", nullable = false, unique = true, length = 10)
+    @Column(length = 10, nullable = false, unique = true)
     private String username;
 
-    @Column(name = "is_location_agreed", nullable = false)
-    private boolean isLocationAgreed = false;
+    @Column(length = 255)
+    private String imageUrl;
 
-    @Column(name = "is_privacy_agreed", nullable = false)
-    private boolean isPrivacyAgreed = false;
+    @Column(length = 70)
+    private String introduction;
 
-    @Column(name = "privacy_agreed_at")
-    private ZonedDateTime privacyAgreedAt;
+    @Column(nullable = false)
+    private boolean isPrivacyAgreed;
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private ZonedDateTime createdAt;
+    @Column(nullable = false)
+    private boolean isLocationAgreed;
 
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    private ZonedDateTime updatedAt;
+    @Column
+    private LocalDateTime privacyAgreedAt;
 
-    @Builder
-    public User(Long providerId, String provider, String username) {
-        this.providerId = providerId;
-        this.provider = provider;
-        this.username = username;
-        this.isLocationAgreed = false;
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    // 생성 전 이벤트
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
         this.isPrivacyAgreed = false;
+        this.isLocationAgreed = false;
     }
 
+    // 수정 전 이벤트
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 프로필 업데이트 메서드
     public void updateProfile(String username, String imageUrl, String introduction) {
-        this.username = username;
+        if (username != null && !username.isEmpty()) {
+            this.username = username;
+        }
         this.imageUrl = imageUrl;
         this.introduction = introduction;
     }
 
+    // 개인정보 동의 설정 메서드
     public void agreeToTerms(boolean isPrivacyAgreed, boolean isLocationAgreed) {
         this.isPrivacyAgreed = isPrivacyAgreed;
         this.isLocationAgreed = isLocationAgreed;
+
         if (isPrivacyAgreed) {
-            this.privacyAgreedAt = ZonedDateTime.now();
+            this.privacyAgreedAt = LocalDateTime.now();
         }
     }
 }

--- a/src/main/java/com/dolpin/domain/user/entity/User.java
+++ b/src/main/java/com/dolpin/domain/user/entity/User.java
@@ -1,0 +1,77 @@
+package com.dolpin.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.ZonedDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "provider_id", nullable = false, unique = true)
+    private Long providerId;
+
+    @Column(name = "provider", nullable = false, length = 10)
+    private String provider;
+
+    @Column(name = "image_url", length = 255)
+    private String imageUrl;
+
+    @Column(name = "introduction", length = 70)
+    private String introduction;
+
+    @Column(name = "username", nullable = false, unique = true, length = 10)
+    private String username;
+
+    @Column(name = "is_location_agreed", nullable = false)
+    private boolean isLocationAgreed = false;
+
+    @Column(name = "is_privacy_agreed", nullable = false)
+    private boolean isPrivacyAgreed = false;
+
+    @Column(name = "privacy_agreed_at")
+    private ZonedDateTime privacyAgreedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private ZonedDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private ZonedDateTime updatedAt;
+
+    @Builder
+    public User(Long providerId, String provider, String username) {
+        this.providerId = providerId;
+        this.provider = provider;
+        this.username = username;
+        this.isLocationAgreed = false;
+        this.isPrivacyAgreed = false;
+    }
+
+    public void updateProfile(String username, String imageUrl, String introduction) {
+        this.username = username;
+        this.imageUrl = imageUrl;
+        this.introduction = introduction;
+    }
+
+    public void agreeToTerms(boolean isPrivacyAgreed, boolean isLocationAgreed) {
+        this.isPrivacyAgreed = isPrivacyAgreed;
+        this.isLocationAgreed = isLocationAgreed;
+        if (isPrivacyAgreed) {
+            this.privacyAgreedAt = ZonedDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/dolpin/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dolpin/domain/user/repository/UserRepository.java
@@ -4,6 +4,10 @@ import com.dolpin.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByProviderAndProviderId(String provider, Long providerId);
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/dolpin/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dolpin/domain/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.dolpin.domain.user.repository;
+
+import com.dolpin.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/dolpin/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/dolpin/domain/user/service/UserCommandService.java
@@ -1,0 +1,11 @@
+package com.dolpin.domain.user.service;
+
+import com.dolpin.domain.auth.service.oauth.OAuthInfoResponse;
+import com.dolpin.domain.user.entity.User;
+
+public interface UserCommandService {
+    User createUser(OAuthInfoResponse oAuthInfo);
+    void updateProfile(Long userId, String username, String imageUrl, String introduction);
+    void agreeToTerms(Long userId, boolean isPrivacyAgreed, boolean isLocationAgreed);
+    void deleteUser(Long userId);
+}

--- a/src/main/java/com/dolpin/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/dolpin/domain/user/service/UserCommandServiceImpl.java
@@ -1,0 +1,91 @@
+package com.dolpin.domain.user.service;
+
+import com.dolpin.domain.auth.service.oauth.OAuthInfoResponse;
+import com.dolpin.domain.user.entity.User;
+import com.dolpin.domain.user.repository.UserRepository;
+import com.dolpin.domain.user.service.UserQueryService;
+import com.dolpin.global.exception.BusinessException;
+import com.dolpin.global.response.ResponseStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService {
+
+    private final UserRepository userRepository;
+    private final UserQueryService userQueryService;
+
+    @Override
+    @Transactional
+    public User createUser(OAuthInfoResponse oAuthInfo) {
+        log.info("Creating new user with provider: {}, providerId: {}",
+                oAuthInfo.getProvider(), oAuthInfo.getProviderId());
+
+        String username = generateUniqueUsername(oAuthInfo.getNickname());
+
+        User user = User.builder()
+                .providerId(Long.parseLong(oAuthInfo.getProviderId()))
+                .provider(oAuthInfo.getProvider())
+                .username(username)
+                .build();
+
+        // 프로필 정보 업데이트
+        user.updateProfile(username, oAuthInfo.getProfileImageUrl(), null);
+
+        return userRepository.save(user);
+    }
+
+    @Override
+    @Transactional
+    public void updateProfile(Long userId, String username, String imageUrl, String introduction) {
+        User user = userQueryService.getUserById(userId);
+        user.updateProfile(username, imageUrl, introduction);
+        userRepository.save(user);
+    }
+
+    @Override
+    @Transactional
+    public void agreeToTerms(Long userId, boolean isPrivacyAgreed, boolean isLocationAgreed) {
+        User user = userQueryService.getUserById(userId);
+        user.agreeToTerms(isPrivacyAgreed, isLocationAgreed);
+        userRepository.save(user);
+    }
+
+    @Override
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userQueryService.getUserById(userId);
+        userRepository.delete(user);
+    }
+
+    private String generateUniqueUsername(String nickname) {
+        if (nickname == null || nickname.isEmpty()) {
+            nickname = "user";
+        }
+
+        // 이름이 10자를 초과하면 잘라냄 (username 필드 길이 제한 때문)
+        if (nickname.length() > 8) {
+            nickname = nickname.substring(0, 8);
+        }
+
+        String candidateUsername = nickname;
+        int suffix = 1;
+
+        while (userRepository.existsByUsername(candidateUsername)) {
+            suffix++;
+            candidateUsername = nickname + suffix;
+
+            // 이름 + 접미사가 10자를 초과하면 이름을 더 자름
+            if (candidateUsername.length() > 10) {
+                nickname = nickname.substring(0, nickname.length() - 1);
+                candidateUsername = nickname + suffix;
+            }
+        }
+
+        return candidateUsername;
+    }
+}

--- a/src/main/java/com/dolpin/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/dolpin/domain/user/service/UserQueryService.java
@@ -1,0 +1,11 @@
+package com.dolpin.domain.user.service;
+
+import com.dolpin.domain.user.entity.User;
+
+import java.util.Optional;
+
+public interface UserQueryService {
+    Optional<User> findByProviderAndProviderId(String provider, Long providerId);
+    User getUserById(Long id);
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/dolpin/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/dolpin/domain/user/service/UserQueryServiceImpl.java
@@ -1,0 +1,37 @@
+package com.dolpin.domain.user.service;
+
+import com.dolpin.domain.user.entity.User;
+import com.dolpin.domain.user.repository.UserRepository;
+import com.dolpin.global.exception.BusinessException;
+import com.dolpin.global.response.ResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryServiceImpl implements UserQueryService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<User> findByProviderAndProviderId(String provider, Long providerId) {
+        return userRepository.findByProviderAndProviderId(provider, providerId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public User getUserById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ResponseStatus.USER_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsByUsername(String username) {
+        return userRepository.existsByUsername(username);
+    }
+}

--- a/src/main/java/com/dolpin/global/config/CorsConfig.java
+++ b/src/main/java/com/dolpin/global/config/CorsConfig.java
@@ -1,0 +1,34 @@
+package com.dolpin.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+
+        // 프론트엔드 애플리케이션의 도메인 허용
+        config.addAllowedOrigin("http://localhost:3000");
+
+        // 필요한 HTTP 메서드 허용
+        config.addAllowedMethod("*");
+
+        // 필요한 헤더 허용
+        config.addAllowedHeader("*");
+
+        // 인증 정보(쿠키) 허용
+        config.setAllowCredentials(true);
+
+        // 모든 API 경로에 CORS 설정 적용
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/dolpin/global/config/WebConfig.java
+++ b/src/main/java/com/dolpin/global/config/WebConfig.java
@@ -1,0 +1,14 @@
+package com.dolpin.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/dolpin/global/exception/BusinessException.java
+++ b/src/main/java/com/dolpin/global/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.dolpin.global.exception;
+
+import com.dolpin.global.response.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ResponseStatus responseStatus;
+
+    public BusinessException(ResponseStatus responseStatus) {
+        super(responseStatus.getMessage());
+        this.responseStatus = responseStatus;
+    }
+
+    public BusinessException(ResponseStatus responseStatus, String message) {
+        super(message);
+        this.responseStatus = responseStatus.withMessage(message);
+    }
+}

--- a/src/main/java/com/dolpin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dolpin/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.dolpin.global.exception;
 
 import com.dolpin.global.response.ApiResponse;
+import com.dolpin.global.response.ResponseStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,11 +12,27 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Object>> handleBusinessException(BusinessException e) {
+        log.error("Business exception occurred: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getResponseStatus().getHttpStatus())
+                .body(ApiResponse.error(e.getResponseStatus()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Object>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("Illegal argument exception occurred: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(ResponseStatus.INVALID_PARAMETER.withMessage(e.getMessage())));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Object>> handleException(Exception e) {
         log.error("Unhandled exception occurred: ", e);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error("서버 내부 오류입니다."));
+                .body(ApiResponse.error(ResponseStatus.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/dolpin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dolpin/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.dolpin.global.exception;
+
+import com.dolpin.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleException(Exception e) {
+        log.error("Unhandled exception occurred: ", e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("서버 내부 오류입니다."));
+    }
+}

--- a/src/main/java/com/dolpin/global/exception/auth/OAuthProviderNotFoundException.java
+++ b/src/main/java/com/dolpin/global/exception/auth/OAuthProviderNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dolpin.global.exception.auth;
+
+import com.dolpin.global.exception.BusinessException;
+import com.dolpin.global.response.ResponseStatus;
+
+public class OAuthProviderNotFoundException extends BusinessException {
+    public OAuthProviderNotFoundException(String provider) {
+        super(ResponseStatus.OAUTH_PROVIDER_NOT_EXIST,
+                "지원하지 않는 OAuth 제공자입니다: " + provider);
+    }
+}

--- a/src/main/java/com/dolpin/global/response/ApiResponse.java
+++ b/src/main/java/com/dolpin/global/response/ApiResponse.java
@@ -1,0 +1,24 @@
+package com.dolpin.global.response;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ApiResponse<T> {
+    private String message;
+    private T data;
+
+    public ApiResponse(String message, T data) {
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(message, data);
+    }
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(message, null);
+    }
+}

--- a/src/main/java/com/dolpin/global/response/ApiResponse.java
+++ b/src/main/java/com/dolpin/global/response/ApiResponse.java
@@ -1,24 +1,34 @@
 package com.dolpin.global.response;
 
-
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
-    private String message;
-    private T data;
+    private final String message;
+    private final T data;
+    private final String code;
 
-    public ApiResponse(String message, T data) {
+    private ApiResponse(String message, T data, String code) {
         this.message = message;
         this.data = data;
+        this.code = code;
     }
 
     public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(message, data);
+        return new ApiResponse<>(message, data, null);
     }
+
+    public static <T> ApiResponse<T> success(ResponseStatus status, T data) {
+        return new ApiResponse<>(status.getMessage(), data, status.name());
+    }
+
     public static <T> ApiResponse<T> error(String message) {
-        return new ApiResponse<>(message, null);
+        return new ApiResponse<>(message, null, null);
+    }
+
+    public static <T> ApiResponse<T> error(ResponseStatus status) {
+        return new ApiResponse<>(status.getMessage(), null, status.name());
     }
 }

--- a/src/main/java/com/dolpin/global/response/ResponseStatus.java
+++ b/src/main/java/com/dolpin/global/response/ResponseStatus.java
@@ -1,0 +1,38 @@
+package com.dolpin.global.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ResponseStatus {
+    // 공통
+    SUCCESS(HttpStatus.OK, "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, "리소스가 성공적으로 생성되었습니다."),
+
+    // 오류
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 파라미터입니다."),
+
+    // 인증/인가
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // OAuth
+    OAUTH_PROVIDER_NOT_EXIST(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth 제공자입니다."),
+
+    // 사용자
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private String message;
+
+    ResponseStatus(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public ResponseStatus withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+}

--- a/src/main/java/com/dolpin/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dolpin/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package com.dolpin.global.security;
+
+import com.dolpin.domain.auth.service.token.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            String token = extractToken(request);
+
+            if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+                Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+                // UserDetails 생성 (Spring Security 인증을 위한 객체)
+                UserDetails userDetails = new User(
+                        userId.toString(),
+                        "",
+                        Collections.emptyList()
+                );
+
+                // Authentication 객체 생성
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities()
+                        );
+
+                // SecurityContext에 Authentication 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.debug("Set Authentication for user: {}", userId);
+            }
+        } catch (Exception e) {
+            log.error("JWT Authentication failed: {}", e.getMessage());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dolpin/global/security/SecurityConfig.java
+++ b/src/main/java/com/dolpin/global/security/SecurityConfig.java
@@ -7,16 +7,20 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final CorsFilter corsFilter;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .addFilter(corsFilter) // CORS 필터 추가
                 .authorizeHttpRequests(authorize -> authorize
                         // 모든 요청 허용
                         .anyRequest().permitAll()

--- a/src/main/java/com/dolpin/global/security/SecurityConfig.java
+++ b/src/main/java/com/dolpin/global/security/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.dolpin.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        // 모든 요청 허용
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,17 +1,22 @@
-spring.application.name=dolpin
+# Server Settings
+server.port=8080
 
-# PostgreSQL ?????? ??
+# Kakao OAuth Settings
+kakao.oauth.client-id=${KAKAO_CLIENT_ID}
+kakao.oauth.redirect-uri=${KAKAO_REDIRECT_URI}
+kakao.oauth.authorization-uri=https://kauth.kakao.com/oauth/authorize
+kakao.oauth.api-url=https://kapi.kakao.com
+
+
+# Database Configuration
 spring.datasource.url=jdbc:postgresql://localhost:5432/dolpin
-spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# JPA ??
+# JPA Configuration
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-
-# ?????? ??
-server.port=8080
-server.servlet.context-path=/api/v1
+spring.jpa.properties.hibernate.spatial.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,10 @@ kakao.oauth.redirect-uri=${KAKAO_REDIRECT_URI}
 kakao.oauth.authorization-uri=https://kauth.kakao.com/oauth/authorize
 kakao.oauth.api-url=https://kapi.kakao.com
 
+# JWT Configuration
+jwt.secret=YourStrongSecretKeyHereWithAtLeast32Bytes123456
+jwt.expiration=3600000
+
 
 # Database Configuration
 spring.datasource.url=jdbc:postgresql://localhost:5432/dolpin


### PR DESCRIPTION
## 📝 PR 개요

OAuth를 통한 카카오 로그인 구현. 추후 다른 소셜 로그인 확장성 고려하여 코드 작성

## 🔍 변경사항

## <!-- 주요 변경사항 목록 (불릿 포인트) -->

- jwt 토큰 설정
- user 엔티티 설정
- 카카오 소셜 로그인 리다이렉트 설정
- CORS 임시 설정

## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
Closes #8 

## 🚨 주의사항 (Optional)

카카오 redirect uri를 임시로 작성해두어서 프론트에서 해당 기능 완성하면 수정할 예정
