### PR TITLE
Feat:CI/CD Docker 컨테이너에 Spring Actuator 모니터링 포트(8081) 노출 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,7 +138,7 @@ docker pull ${env.GAR_IMAGE}
 sudo docker run -d --name ${env.CONTAINER_NAME} \
   --env-file /home/${env.SSH_USER}/.env \
   -v /home/${env.SSH_USER}/gcp-key.json:/home/${env.SSH_USER}/gcp-key.json \
-  -p ${env.PORT}:${env.PORT} \
+  -p ${env.PORT}:${env.PORT} -p 8081:8081 \
   ${env.GAR_IMAGE}
 
 """


### PR DESCRIPTION
## 📝 PR 개요

<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
CI/CD 파이프라인에서 Docker 컨테이너를 실행할 때, Prometheus가 Spring Boot Actuator를 모니터링할 수 있도록 포트 매핑을 추가

## 🔍 변경사항

- Docker 실행 옵션에 Actuator 모니터링 포트(8081) 매핑 추가
## 🔗 관련 이슈
 #145
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->

