### PR TITLE
Feat#160

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,26 +43,30 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	// 테스트
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-
-	//환경변수
+	// 환경변수
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 
-	// Spring Boot Test (JUnit5)
+	// 테스트 의존성
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 
-	// Testcontainers
-	testImplementation 'org.testcontainers:junit-jupiter:1.18.3'
-	testImplementation 'org.testcontainers:postgresql:1.18.3'
+	// Testcontainers - PostgreSQL 지원 (최신 버전으로 업데이트)
+	testImplementation 'org.testcontainers:junit-jupiter:1.20.0'
+	testImplementation 'org.testcontainers:postgresql:1.20.0'
 
-	// 실제 PostgreSQL 드라이버
+	// PostgreSQL 드라이버 (테스트용)
 	testImplementation 'org.postgresql:postgresql:42.5.4'
+
+	// AssertJ (더 나은 assertion)
+	testImplementation 'org.assertj:assertj-core:3.24.2'
+
+	// Mockito (Mock 객체 생성)
+	testImplementation 'org.mockito:mockito-core:5.1.1'
+	testImplementation 'org.mockito:mockito-junit-jupiter:5.1.1'
 }
 
 // QueryDSL 설정
@@ -76,6 +80,25 @@ sourceSets {
 
 tasks.withType(Test) {
 	useJUnitPlatform()
+
+	// 테스트 시스템 프로퍼티 설정
+	systemProperty 'spring.profiles.active', 'test'
+
+	// 테스트 메모리 설정
+	minHeapSize = "512m"
+	maxHeapSize = "2g"
+
+	// 테스트 병렬 실행 설정 (선택사항)
+	maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+
+	// 테스트 결과 출력 설정
+	testLogging {
+		events "passed", "skipped", "failed", "standardOut", "standardError"
+		exceptionFormat "full"
+		showCauses true
+		showExceptions true
+		showStackTraces true
+	}
 }
 
 // QueryDSL 설정

--- a/src/main/java/com/dolpin/domain/place/service/query/PlaceQueryServiceImpl.java
+++ b/src/main/java/com/dolpin/domain/place/service/query/PlaceQueryServiceImpl.java
@@ -472,12 +472,21 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
 
     // 시간 문자열을 분 단위로 변환하는 헬퍼 메서드
     private int parseTimeToMinutes(String timeString) {
+        if (timeString == null || !timeString.contains(":")) {
+            return 0;
+        }
+        String[] parts = timeString.split(":");
+        if (parts.length != 2) {
+            return 0;
+        }
         try {
-            String[] parts = timeString.split(":");
             int hour = Integer.parseInt(parts[0]);
             int minute = Integer.parseInt(parts[1]);
+            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+                return 0;
+            }
             return hour * 60 + minute;
-        } catch (Exception e) {
+        } catch (NumberFormatException e) {
             return 0;
         }
     }

--- a/src/test/java/com/dolpin/DolpinApplicationTests.java
+++ b/src/test/java/com/dolpin/DolpinApplicationTests.java
@@ -1,5 +1,6 @@
 package com.dolpin;
 
+import com.dolpin.global.config.TestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/dolpin/DolpinApplicationTests.java
+++ b/src/test/java/com/dolpin/DolpinApplicationTests.java
@@ -29,8 +29,7 @@ class DolpinApplicationTests {
             new PostgreSQLContainer<>(POSTGIS_IMAGE)
                     .withDatabaseName("testdb")
                     .withUsername("test")
-                    .withPassword("test")
-                    .withInitScript("init-postgis.sql");
+                    .withPassword("test");
 
     @DynamicPropertySource
     static void overrideProperties(DynamicPropertyRegistry registry) {

--- a/src/test/java/com/dolpin/domain/place/entity/PlaceTest.java
+++ b/src/test/java/com/dolpin/domain/place/entity/PlaceTest.java
@@ -1,0 +1,44 @@
+package com.dolpin.domain.place.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Place 엔티티 테스트")
+class PlaceTest {
+
+    @Test
+    @DisplayName("Place 생성 시 createdAt, updatedAt이 자동 설정된다")
+    void prePersist_SetsTimestamps() {
+        // given
+        Place place = new Place();
+
+        // when
+        place.prePersist();
+
+        // then
+        assertThat(place.getCreatedAt()).isNotNull();
+        assertThat(place.getUpdatedAt()).isNotNull();
+        assertThat(place.getCreatedAt()).isEqualTo(place.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("Place 수정 시 updatedAt이 갱신된다")
+    void preUpdate_UpdatesTimestamp() throws InterruptedException {
+        // given
+        Place place = new Place();
+        place.prePersist();
+        LocalDateTime originalUpdatedAt = place.getUpdatedAt();
+
+        Thread.sleep(1);
+
+        // when
+        place.preUpdate();
+
+        // then
+        assertThat(place.getUpdatedAt()).isAfter(originalUpdatedAt);
+    }
+}

--- a/src/test/java/com/dolpin/domain/place/repository/PlaceRepositoryTest.java
+++ b/src/test/java/com/dolpin/domain/place/repository/PlaceRepositoryTest.java
@@ -5,6 +5,7 @@ import com.dolpin.domain.place.entity.Keyword;
 import com.dolpin.domain.place.entity.Place;
 import com.dolpin.global.config.TestConfig;
 import com.dolpin.global.fixture.PlaceFixture;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("PlaceRepository 테스트")
 class PlaceRepositoryTest {
 
-    // PostGIS가 포함된 이미지 사용
+    // PostGIS가 포함된 이미지 사용 (PostgreSQL 호환성 명시)
     private static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
             DockerImageName.parse("postgis/postgis:15-3.3-alpine")
                     .asCompatibleSubstituteFor("postgres"))
@@ -44,6 +45,11 @@ class PlaceRepositoryTest {
     @BeforeAll
     static void beforeAll() {
         postgres.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        postgres.stop();
     }
 
     static class TestContainerInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {

--- a/src/test/java/com/dolpin/domain/place/repository/PlaceRepositoryTest.java
+++ b/src/test/java/com/dolpin/domain/place/repository/PlaceRepositoryTest.java
@@ -1,0 +1,399 @@
+package com.dolpin.domain.place.repository;
+
+import com.dolpin.domain.place.dto.response.PlaceWithDistance;
+import com.dolpin.domain.place.entity.Keyword;
+import com.dolpin.domain.place.entity.Place;
+import com.dolpin.global.config.TestConfig;
+import com.dolpin.global.fixture.PlaceFixture;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(TestConfig.class)
+@ContextConfiguration(initializers = PlaceRepositoryTest.TestContainerInitializer.class)
+@DisplayName("PlaceRepository 테스트")
+class PlaceRepositoryTest {
+
+    // PostGIS가 포함된 이미지 사용
+    private static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgis/postgis:15-3.3-alpine")
+                    .asCompatibleSubstituteFor("postgres"))
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @BeforeAll
+    static void beforeAll() {
+        postgres.start();
+    }
+
+    static class TestContainerInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        @Override
+        public void initialize(ConfigurableApplicationContext context) {
+            TestPropertyValues.of(
+                    "spring.datasource.url=" + postgres.getJdbcUrl(),
+                    "spring.datasource.username=" + postgres.getUsername(),
+                    "spring.datasource.password=" + postgres.getPassword(),
+                    "spring.datasource.driver-class-name=org.postgresql.Driver"
+            ).applyTo(context.getEnvironment());
+        }
+    }
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Nested
+    @DisplayName("기본 조회 테스트")
+    class BasicQueryTest {
+
+        @Test
+        @DisplayName("ID로 기본 장소 정보 조회가 정상 동작한다")
+        void findBasicPlaceById_ReturnsPlace() {
+            // given
+            Long placeId = PlaceFixture.createPlaceWithCategory(entityManager, "테스트 카페", "카페", 37.5665, 126.9780);
+
+            // when
+            Optional<Place> result = placeRepository.findBasicPlaceById(placeId);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getName()).isEqualTo("테스트 카페");
+            assertThat(result.get().getCategory()).isEqualTo("카페");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID로 조회하면 빈 결과를 반환한다")
+        void findBasicPlaceById_WithNonExistentId_ReturnsEmpty() {
+            // given
+            Long nonExistentId = 999L;
+
+            // when
+            Optional<Place> result = placeRepository.findBasicPlaceById(nonExistentId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("연관 관계 조회 테스트")
+    class AssociationQueryTest {
+
+        @Test
+        @DisplayName("키워드를 포함한 장소 정보 조회가 정상 동작한다")
+        void findByIdWithKeywords_ReturnsPlaceWithKeywords() {
+            // given
+            Long placeId = PlaceFixture.createPlaceWithCategory(entityManager, "테스트 카페", "카페", 37.5665, 126.9780);
+            Keyword keyword1 = PlaceFixture.createAndPersistKeyword(entityManager, "아늑한");
+            Keyword keyword2 = PlaceFixture.createAndPersistKeyword(entityManager, "맛있는");
+
+            PlaceFixture.createAndPersistPlaceKeyword(entityManager, placeId, keyword1.getId());
+            PlaceFixture.createAndPersistPlaceKeyword(entityManager, placeId, keyword2.getId());
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            Optional<Place> result = placeRepository.findByIdWithKeywords(placeId);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getKeywords()).hasSize(2);
+
+            List<String> keywords = result.get().getKeywords().stream()
+                    .map(pk -> pk.getKeyword().getKeyword())
+                    .toList();
+            assertThat(keywords).containsExactlyInAnyOrder("아늑한", "맛있는");
+        }
+
+        @Test
+        @DisplayName("키워드가 없는 장소도 정상 조회된다")
+        void findByIdWithKeywords_WithNoKeywords_ReturnsPlace() {
+            // given
+            Long placeId = PlaceFixture.createPlaceWithCategory(entityManager, "키워드 없는 카페", "카페", 37.5665, 126.9780);
+
+            // when
+            Optional<Place> result = placeRepository.findByIdWithKeywords(placeId);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getKeywords()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("메뉴를 포함한 장소 정보 조회가 정상 동작한다")
+        void findByIdWithMenus_ReturnsPlaceWithMenus() {
+            // given
+            Long placeId = PlaceFixture.createPlaceWithCategory(entityManager, "테스트 카페", "카페", 37.5665, 126.9780);
+            PlaceFixture.createAndPersistPlaceMenu(entityManager, placeId, "아메리카노", 4000);
+            PlaceFixture.createAndPersistPlaceMenu(entityManager, placeId, "라떼", 4500);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            Optional<Place> result = placeRepository.findByIdWithMenus(placeId);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getMenus()).hasSize(2);
+
+            List<String> menuNames = result.get().getMenus().stream()
+                    .map(menu -> menu.getMenuName())
+                    .toList();
+            assertThat(menuNames).containsExactlyInAnyOrder("아메리카노", "라떼");
+        }
+
+        @Test
+        @DisplayName("영업시간을 포함한 장소 정보 조회가 정상 동작한다")
+        void findByIdWithHours_ReturnsPlaceWithHours() {
+            // given
+            Long placeId = PlaceFixture.createPlaceWithCategory(entityManager, "테스트 카페", "카페", 37.5665, 126.9780);
+            PlaceFixture.createAndPersistPlaceHours(entityManager, placeId, "월", "09:00", "21:00");
+            PlaceFixture.createAndPersistPlaceHours(entityManager, placeId, "화", "09:00", "21:00");
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            Optional<Place> result = placeRepository.findByIdWithHours(placeId);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getHours()).hasSize(2);
+
+            List<String> days = result.get().getHours().stream()
+                    .map(hours -> hours.getDayOfWeek())
+                    .toList();
+            assertThat(days).containsExactlyInAnyOrder("월", "화");
+        }
+
+        @Test
+        @DisplayName("여러 ID로 키워드 포함 장소들 조회가 정상 동작한다")
+        void findByIdsWithKeywords_ReturnsPlacesWithKeywords() {
+            // given
+            Long place1Id = PlaceFixture.createPlaceWithCategory(entityManager, "카페1", "카페", 37.5665, 126.9780);
+            Long place2Id = PlaceFixture.createPlaceWithCategory(entityManager, "카페2", "카페", 37.5666, 126.9781);
+
+            Keyword keyword = PlaceFixture.createAndPersistKeyword(entityManager, "좋은");
+            PlaceFixture.createAndPersistPlaceKeyword(entityManager, place1Id, keyword.getId());
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            List<Place> results = placeRepository.findByIdsWithKeywords(List.of(place1Id, place2Id));
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results.stream().map(Place::getName)).containsExactlyInAnyOrder("카페1", "카페2");
+        }
+    }
+
+    @Nested
+    @DisplayName("공간 쿼리 테스트")
+    class SpatialQueryTest {
+
+        @Test
+        @DisplayName("반경 내 특정 장소들 검색이 정상 동작한다")
+        void findPlacesWithinRadiusByIds_ReturnsNearbyPlaces() {
+            // given
+            Long nearPlaceId = PlaceFixture.createPlaceWithCategory(entityManager, "가까운 카페", "카페", 37.5665, 126.9780);
+            Long farPlaceId = PlaceFixture.createPlaceWithCategory(entityManager, "먼 카페", "카페", 37.6665, 127.0780);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            List<Long> placeIds = List.of(nearPlaceId, farPlaceId);
+            Double centerLat = 37.5665;
+            Double centerLng = 126.9780;
+            Double radius = 1000.0; // 1km
+
+            // when
+            List<PlaceWithDistance> results = placeRepository.findPlacesWithinRadiusByIds(
+                    placeIds, centerLat, centerLng, radius);
+
+            // then
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getName()).isEqualTo("가까운 카페");
+            assertThat(results.get(0).getDistance()).isLessThan(radius);
+        }
+
+        @Test
+        @DisplayName("반경이 매우 클 때 모든 장소가 조회된다")
+        void findPlacesWithinRadiusByIds_WithLargeRadius_ReturnsAllPlaces() {
+            // given
+            Long place1Id = PlaceFixture.createPlaceWithCategory(entityManager, "카페1", "카페", 37.5665, 126.9780);
+            Long place2Id = PlaceFixture.createPlaceWithCategory(entityManager, "카페2", "카페", 37.6665, 127.0780);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            List<Long> placeIds = List.of(place1Id, place2Id);
+            Double centerLat = 37.5665;
+            Double centerLng = 126.9780;
+            Double radius = 50000.0; // 50km
+
+            // when
+            List<PlaceWithDistance> results = placeRepository.findPlacesWithinRadiusByIds(
+                    placeIds, centerLat, centerLng, radius);
+
+            // then
+            assertThat(results).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("카테고리별 반경 내 장소 검색이 정상 동작한다")
+        void findPlacesByCategoryWithinRadius_ReturnsPlacesByCategory() {
+            // given
+            PlaceFixture.createPlaceWithCategory(entityManager, "테스트 카페", "카페", 37.5665, 126.9780);
+            PlaceFixture.createPlaceWithCategory(entityManager, "테스트 식당", "식당", 37.5666, 126.9781);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            String category = "카페";
+            Double centerLat = 37.5665;
+            Double centerLng = 126.9780;
+            Double radius = 1000.0;
+
+            // when
+            List<PlaceWithDistance> results = placeRepository.findPlacesByCategoryWithinRadius(
+                    category, centerLat, centerLng, radius);
+
+            // then
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getName()).isEqualTo("테스트 카페");
+            assertThat(results.get(0).getCategory()).isEqualTo("카페");
+        }
+
+        @Test
+        @DisplayName("카테고리별 검색 결과가 거리순으로 정렬된다")
+        void findPlacesByCategoryWithinRadius_ResultsOrderedByDistance() {
+            // given
+            PlaceFixture.createPlaceWithCategory(entityManager, "가까운 카페", "카페", 37.5665, 126.9780);
+            PlaceFixture.createPlaceWithCategory(entityManager, "먼 카페", "카페", 37.5670, 126.9785);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            String category = "카페";
+            Double centerLat = 37.5665;
+            Double centerLng = 126.9780;
+            Double radius = 10000.0; // 충분히 큰 반경
+
+            // when
+            List<PlaceWithDistance> results = placeRepository.findPlacesByCategoryWithinRadius(
+                    category, centerLat, centerLng, radius);
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results.get(0).getName()).isEqualTo("가까운 카페");
+            assertThat(results.get(1).getName()).isEqualTo("먼 카페");
+            assertThat(results.get(0).getDistance()).isLessThan(results.get(1).getDistance());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리 검색 시 빈 결과를 반환한다")
+        void findPlacesByCategoryWithinRadius_WithNonExistentCategory_ReturnsEmpty() {
+            // given
+            PlaceFixture.createPlaceWithCategory(entityManager, "테스트 카페", "카페", 37.5665, 126.9780);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            String nonExistentCategory = "존재하지않는카테고리";
+            Double centerLat = 37.5665;
+            Double centerLng = 126.9780;
+            Double radius = 1000.0;
+
+            // when
+            List<PlaceWithDistance> results = placeRepository.findPlacesByCategoryWithinRadius(
+                    nonExistentCategory, centerLat, centerLng, radius);
+
+            // then
+            assertThat(results).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 조회 테스트")
+    class CategoryQueryTest {
+
+        @Test
+        @DisplayName("카테고리 목록 조회가 정상 동작한다")
+        void findDistinctCategories_ReturnsCategories() {
+            // given
+            PlaceFixture.createPlaceWithCategory(entityManager, "카페1", "카페", 37.5665, 126.9780);
+            PlaceFixture.createPlaceWithCategory(entityManager, "식당1", "식당", 37.5666, 126.9781);
+            PlaceFixture.createPlaceWithCategory(entityManager, "술집1", "술집", 37.5667, 126.9782);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            List<String> categories = placeRepository.findDistinctCategories();
+
+            // then
+            assertThat(categories).containsExactlyInAnyOrder("카페", "식당", "술집");
+        }
+
+        @Test
+        @DisplayName("카테고리가 많은 순서대로 정렬되어 조회된다")
+        void findDistinctCategories_OrderedByCount() {
+            // given - 카페 3개, 식당 2개, 술집 1개
+            PlaceFixture.createPlaceWithCategory(entityManager, "카페1", "카페", 37.5665, 126.9780);
+            PlaceFixture.createPlaceWithCategory(entityManager, "카페2", "카페", 37.5666, 126.9781);
+            PlaceFixture.createPlaceWithCategory(entityManager, "카페3", "카페", 37.5667, 126.9782);
+            PlaceFixture.createPlaceWithCategory(entityManager, "식당1", "식당", 37.5668, 126.9783);
+            PlaceFixture.createPlaceWithCategory(entityManager, "식당2", "식당", 37.5669, 126.9784);
+            PlaceFixture.createPlaceWithCategory(entityManager, "술집1", "술집", 37.5670, 126.9785);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            List<String> categories = placeRepository.findDistinctCategories();
+
+            // then
+            assertThat(categories).hasSize(3);
+            assertThat(categories.get(0)).isEqualTo("카페"); // 가장 많음
+            assertThat(categories.get(1)).isEqualTo("식당"); // 두 번째로 많음
+            assertThat(categories.get(2)).isEqualTo("술집"); // 가장 적음
+        }
+
+        @Test
+        @DisplayName("장소가 없으면 빈 카테고리 목록을 반환한다")
+        void findDistinctCategories_WithNoPlaces_ReturnsEmpty() {
+            // given - 장소 없음
+
+            // when
+            List<String> categories = placeRepository.findDistinctCategories();
+
+            // then
+            assertThat(categories).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/dolpin/domain/place/service/query/BusinessHoursUtilTest.java
+++ b/src/test/java/com/dolpin/domain/place/service/query/BusinessHoursUtilTest.java
@@ -1,0 +1,410 @@
+package com.dolpin.domain.place.service.query;
+
+import com.dolpin.domain.place.dto.response.PlaceDetailResponse;
+import com.dolpin.domain.place.entity.PlaceHours;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static com.dolpin.global.helper.PlaceTestHelper.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("영업시간 및 유틸리티 메서드 테스트")
+class BusinessHoursUtilTest {
+
+    private final PlaceQueryServiceImpl placeQueryService = new PlaceQueryServiceImpl(null, null);
+
+    @Nested
+    @DisplayName("Private 메서드 간접 테스트")
+    class PrivateMethodsTest {
+
+        @ParameterizedTest
+        @CsvSource({
+                "500.0, 500m",
+                "999.9, 1000m",
+                "1000.0, 1.0km",
+                "1500.0, 1.5km",
+                "2340.7, 2.3km",
+                "10000.0, 10.0km"
+        })
+        @DisplayName("formatDistance 거리 포맷팅이 정상 동작한다")
+        void formatDistance_FormatsDistanceCorrectly(double distance, String expected) throws Exception {
+            // given
+            Method formatDistanceMethod = PlaceQueryServiceImpl.class.getDeclaredMethod("formatDistance", Double.class);
+            formatDistanceMethod.setAccessible(true);
+
+            // when
+            String result = (String) formatDistanceMethod.invoke(placeQueryService, distance);
+
+            // then
+            assertThat(result).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("formatDistance null 입력 시 0을 반환한다")
+        void formatDistance_WithNull_ReturnsZero() throws Exception {
+            // given
+            Method formatDistanceMethod = PlaceQueryServiceImpl.class.getDeclaredMethod("formatDistance", Double.class);
+            formatDistanceMethod.setAccessible(true);
+
+            // when
+            String result = (String) formatDistanceMethod.invoke(placeQueryService, (Double) null);
+
+            // then
+            assertThat(result).isEqualTo("0");
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "09:30, 570",
+                "12:00, 720",
+                "18:45, 1125",
+                "23:59, 1439",
+                "00:00, 0"
+        })
+        @DisplayName("parseTimeToMinutes 시간 파싱이 정상 동작한다")
+        void parseTimeToMinutes_ParsesTimeCorrectly(String timeString, int expectedMinutes) throws Exception {
+            // given
+            Method parseTimeToMinutesMethod = PlaceQueryServiceImpl.class.getDeclaredMethod("parseTimeToMinutes", String.class);
+            parseTimeToMinutesMethod.setAccessible(true);
+
+            // when
+            int result = (int) parseTimeToMinutesMethod.invoke(placeQueryService, timeString);
+
+            // then
+            assertThat(result).isEqualTo(expectedMinutes);
+        }
+
+        @Test
+        @DisplayName("parseTimeToMinutes 잘못된 형식 입력 시 0을 반환한다")
+        void parseTimeToMinutes_WithInvalidFormat_ReturnsZero() throws Exception {
+            // given
+            Method parseTimeToMinutesMethod = PlaceQueryServiceImpl.class.getDeclaredMethod("parseTimeToMinutes", String.class);
+            parseTimeToMinutesMethod.setAccessible(true);
+
+            // when & then
+            assertThat((int) parseTimeToMinutesMethod.invoke(placeQueryService, "invalid")).isEqualTo(0);
+            assertThat((int) parseTimeToMinutesMethod.invoke(placeQueryService, "25:00")).isEqualTo(0);
+            assertThat((int) parseTimeToMinutesMethod.invoke(placeQueryService, "")).isEqualTo(0);
+            assertThat((int) parseTimeToMinutesMethod.invoke(placeQueryService, (String) null)).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("buildDaySchedules 요일별 스케줄 구성이 정상 동작한다")
+        void buildDaySchedules_BuildsSchedulesCorrectly() throws Exception {
+            // given
+            List<PlaceHours> placeHours = createCompleteBusinessHours();
+
+            Method buildDaySchedulesMethod = PlaceQueryServiceImpl.class.getDeclaredMethod("buildDaySchedules", List.class);
+            buildDaySchedulesMethod.setAccessible(true);
+
+            // when
+            @SuppressWarnings("unchecked")
+            List<PlaceDetailResponse.Schedule> result = (List<PlaceDetailResponse.Schedule>)
+                    buildDaySchedulesMethod.invoke(placeQueryService, placeHours);
+
+            // then
+            assertThat(result).hasSize(7); // 7일
+
+            // 월요일 확인 (영업 + 브레이크타임)
+            Optional<PlaceDetailResponse.Schedule> monday = result.stream()
+                    .filter(s -> "mon".equals(s.getDay())).findFirst();
+            assertThat(monday).isPresent();
+            assertThat(monday.get().getHours()).isEqualTo("09:00~21:00");
+            assertThat(monday.get().getBreakTime()).isEqualTo("15:00~16:00");
+
+            // 일요일 확인 (휴무일)
+            Optional<PlaceDetailResponse.Schedule> sunday = result.stream()
+                    .filter(s -> "sun".equals(s.getDay())).findFirst();
+            assertThat(sunday).isPresent();
+            assertThat(sunday.get().getHours()).isNull();
+            assertThat(sunday.get().getBreakTime()).isNull();
+        }
+
+        @ParameterizedTest
+        @MethodSource("businessStatusTestCases")
+        @DisplayName("determineBusinessStatus 영업 상태 판단이 정상 동작한다")
+        void determineBusinessStatus_DeterminesStatusCorrectly(
+                List<PlaceHours> hours, String expectedStatus) throws Exception {
+            // given
+            Method determineBusinessStatusMethod = PlaceQueryServiceImpl.class
+                    .getDeclaredMethod("determineBusinessStatus", List.class);
+            determineBusinessStatusMethod.setAccessible(true);
+
+            // when
+            String result = (String) determineBusinessStatusMethod.invoke(placeQueryService, hours);
+
+            // then
+            assertThat(result).isEqualTo(expectedStatus);
+        }
+
+        @Test
+        @DisplayName("determineBusinessStatus 영업 중 반환 테스트")
+        void determineBusinessStatus_WhenWithinOpenHours_ReturnsOpen() throws Exception {
+            // 2025-05-26 12:00 서울 기준
+            ZonedDateTime now = ZonedDateTime.of(2025, 5, 26, 12, 0, 0, 0, ZoneId.of("Asia/Seoul"));
+            PlaceHours todayHours = createMockHours("월", "00:00", "23:59", false);
+
+            Method m = PlaceQueryServiceImpl.class.getDeclaredMethod("determineBusinessStatus", List.class);
+            m.setAccessible(true);
+
+            try (MockedStatic<ZonedDateTime> mockNow = Mockito.mockStatic(ZonedDateTime.class)) {
+                mockNow.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(now);
+                String status = (String) m.invoke(placeQueryService, List.of(todayHours));
+                assertThat(status).isEqualTo("영업 중");
+            }
+        }
+
+        @Test
+        @DisplayName("determineBusinessStatus 브레이크 타임 반환 테스트")
+        void determineBusinessStatus_WhenDuringBreakTime_ReturnsBreak() throws Exception {
+            ZonedDateTime now = ZonedDateTime.of(2025, 5, 26, 12, 30, 0, 0, ZoneId.of("Asia/Seoul"));
+            String day = "월";
+
+            PlaceHours openSlot = createMockHours(day, "00:00", "23:59", false);
+            PlaceHours breakSlot = createMockHours(day, "12:00", "13:00", true);
+
+            Method m = PlaceQueryServiceImpl.class.getDeclaredMethod("determineBusinessStatus", List.class);
+            m.setAccessible(true);
+
+            try (MockedStatic<ZonedDateTime> mockNow = Mockito.mockStatic(ZonedDateTime.class)) {
+                mockNow.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(now);
+                String status = (String) m.invoke(placeQueryService, List.of(openSlot, breakSlot));
+                assertThat(status).isEqualTo("브레이크 타임");
+            }
+        }
+
+        @Test
+        @DisplayName("determineBusinessStatus 영업 종료 반환 테스트")
+        void determineBusinessStatus_WhenAfterCloseTime_ReturnsClosed() throws Exception {
+            ZonedDateTime now = ZonedDateTime.of(2025, 5, 26, 22, 0, 0, 0, ZoneId.of("Asia/Seoul"));
+            String day = "월";
+
+            PlaceHours earlyClose = createMockHours(day, "09:00", "20:00", false);
+
+            Method m = PlaceQueryServiceImpl.class.getDeclaredMethod("determineBusinessStatus", List.class);
+            m.setAccessible(true);
+
+            try (MockedStatic<ZonedDateTime> mockNow = Mockito.mockStatic(ZonedDateTime.class)) {
+                mockNow.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(now);
+                String status = (String) m.invoke(placeQueryService, List.of(earlyClose));
+                assertThat(status).isEqualTo("영업 종료");
+            }
+        }
+
+        private static Stream<Arguments> businessStatusTestCases() {
+            return Stream.of(
+                    Arguments.of(Collections.emptyList(), "영업 여부 확인 필요"),
+                    Arguments.of((List<PlaceHours>) null, "영업 여부 확인 필요"),
+                    Arguments.of(createClosedDayHours(), "휴무일")
+            );
+        }
+
+        private static List<PlaceHours> createClosedDayHours() {
+            // 현재 요일로 설정 (테스트가 실행되는 시점의 요일)
+            ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+            String currentDay = switch (now.getDayOfWeek()) {
+                case MONDAY -> "월";
+                case TUESDAY -> "화";
+                case WEDNESDAY -> "수";
+                case THURSDAY -> "목";
+                case FRIDAY -> "금";
+                case SATURDAY -> "토";
+                case SUNDAY -> "일";
+            };
+
+            PlaceHours closedHours = mock(PlaceHours.class);
+            given(closedHours.getDayOfWeek()).willReturn(currentDay);
+            given(closedHours.getIsBreakTime()).willReturn(false);
+            given(closedHours.getOpenTime()).willReturn(null);
+            given(closedHours.getCloseTime()).willReturn(null);
+
+            return List.of(closedHours);
+        }
+    }
+
+    @Nested
+    @DisplayName("복잡한 영업시간 엣지 케이스 테스트")
+    class ComplexBusinessHoursTest {
+
+        @Test
+        @DisplayName("자정을 넘어가는 영업시간 - 영업 중 상태")
+        void determineBusinessStatus_WithMidnightCrossing_WhenOpen_ReturnsOpen() throws Exception {
+            // 2025-05-26 01:30 (월요일 새벽)
+            ZonedDateTime lateNight = ZonedDateTime.of(2025, 5, 26, 1, 30, 0, 0, ZoneId.of("Asia/Seoul"));
+
+            // 월요일 00:00 ~ 02:00 영업 (자정 넘어가는 영업의 후반부)
+            PlaceHours mondayEarlyHours = createMockHours("월", "00:00", "02:00", false);
+
+            Method method = PlaceQueryServiceImpl.class.getDeclaredMethod("determineBusinessStatus", List.class);
+            method.setAccessible(true);
+
+            try (MockedStatic<ZonedDateTime> mockNow = Mockito.mockStatic(ZonedDateTime.class)) {
+                mockNow.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(lateNight);
+
+                // when
+                String status = (String) method.invoke(placeQueryService, List.of(mondayEarlyHours));
+
+                // then
+                assertThat(status).isEqualTo("영업 중");
+            }
+        }
+
+        @Test
+        @DisplayName("자정을 넘어가는 영업시간 - 영업 종료 상태")
+        void determineBusinessStatus_WithMidnightCrossing_WhenClosed_ReturnsClosed() throws Exception {
+            // 2025-05-26 03:00 (월요일 새벽)
+            ZonedDateTime earlyMorning = ZonedDateTime.of(2025, 5, 26, 3, 0, 0, 0, ZoneId.of("Asia/Seoul"));
+
+            // 월요일 00:00 ~ 02:00 영업 (이미 마감됨)
+            PlaceHours mondayEarlyHours = createMockHours("월", "00:00", "02:00", false);
+
+            Method method = PlaceQueryServiceImpl.class.getDeclaredMethod("determineBusinessStatus", List.class);
+            method.setAccessible(true);
+
+            try (MockedStatic<ZonedDateTime> mockNow = Mockito.mockStatic(ZonedDateTime.class)) {
+                mockNow.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(earlyMorning);
+
+                // when
+                String status = (String) method.invoke(placeQueryService, List.of(mondayEarlyHours));
+
+                // then
+                assertThat(status).isEqualTo("영업 종료");
+            }
+        }
+
+        @Test
+        @DisplayName("24시간 운영 - 항상 영업 중")
+        void determineBusinessStatus_With24HourOperation_AlwaysReturnsOpen() throws Exception {
+            // 다양한 시간대 테스트
+            List<ZonedDateTime> testTimes = List.of(
+                    ZonedDateTime.of(2025, 5, 26, 3, 0, 0, 0, ZoneId.of("Asia/Seoul")),   // 새벽 3시
+                    ZonedDateTime.of(2025, 5, 26, 12, 0, 0, 0, ZoneId.of("Asia/Seoul")),  // 정오
+                    ZonedDateTime.of(2025, 5, 26, 18, 0, 0, 0, ZoneId.of("Asia/Seoul")),  // 저녁 6시
+                    ZonedDateTime.of(2025, 5, 26, 23, 59, 0, 0, ZoneId.of("Asia/Seoul"))  // 밤 11시 59분
+            );
+
+            // 24시간 운영 (00:00 ~ 00:00)
+            PlaceHours twentyFourHours = createMockHours("월", "00:00", "00:00", false);
+
+            Method method = PlaceQueryServiceImpl.class.getDeclaredMethod("determineBusinessStatus", List.class);
+            method.setAccessible(true);
+
+            for (ZonedDateTime testTime : testTimes) {
+                try (MockedStatic<ZonedDateTime> mockNow = Mockito.mockStatic(ZonedDateTime.class)) {
+                    mockNow.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(testTime);
+
+                    // when
+                    String status = (String) method.invoke(placeQueryService, List.of(twentyFourHours));
+
+                    // then
+                    assertThat(status).as("시간 %s에서 24시간 운영 상태 확인", testTime.toLocalTime())
+                            .isEqualTo("영업 중");
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("경계 시간 테스트 - 오픈/마감 시각 정확한 처리")
+        void determineBusinessStatus_AtBoundaryTimes_HandlesExactly() throws Exception {
+            String day = "월";
+
+            // 09:00-18:00 영업
+            PlaceHours normalHours = createMockHours(day, "09:00", "18:00", false);
+
+            Method method = PlaceQueryServiceImpl.class.getDeclaredMethod("determineBusinessStatus", List.class);
+            method.setAccessible(true);
+
+            // 테스트 케이스들
+            Map<ZonedDateTime, String> boundaryTests = Map.of(
+                    // 오픈 시각 정확히
+                    ZonedDateTime.of(2025, 5, 26, 9, 0, 0, 0, ZoneId.of("Asia/Seoul")), "영업 중",
+                    // 오픈 1분 전
+                    ZonedDateTime.of(2025, 5, 26, 8, 59, 0, 0, ZoneId.of("Asia/Seoul")), "영업 종료",
+                    // 마감 1분 전
+                    ZonedDateTime.of(2025, 5, 26, 17, 59, 0, 0, ZoneId.of("Asia/Seoul")), "영업 중",
+                    // 마감 시각 정확히
+                    ZonedDateTime.of(2025, 5, 26, 18, 0, 0, 0, ZoneId.of("Asia/Seoul")), "영업 종료",
+                    // 마감 1분 후
+                    ZonedDateTime.of(2025, 5, 26, 18, 1, 0, 0, ZoneId.of("Asia/Seoul")), "영업 종료"
+            );
+
+            for (Map.Entry<ZonedDateTime, String> test : boundaryTests.entrySet()) {
+                ZonedDateTime time = test.getKey();
+                String expected = test.getValue();
+
+                try (MockedStatic<ZonedDateTime> mockNow = Mockito.mockStatic(ZonedDateTime.class)) {
+                    mockNow.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(time);
+
+                    // when
+                    String status = (String) method.invoke(placeQueryService, List.of(normalHours));
+
+                    // then
+                    assertThat(status).as("시각 %s에서의 영업 상태", time.toLocalTime())
+                            .isEqualTo(expected);
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("브레이크 타임 경계 시간 테스트")
+        void determineBusinessStatus_AtBreakTimeBoundaries_HandlesExactly() throws Exception {
+            String day = "월";
+
+            // 09:00-18:00 영업
+            PlaceHours normalHours = createMockHours(day, "09:00", "18:00", false);
+
+            // 12:00-13:00 브레이크 타임
+            PlaceHours breakHours = createMockHours(day, "12:00", "13:00", true);
+
+            Method method = PlaceQueryServiceImpl.class.getDeclaredMethod("determineBusinessStatus", List.class);
+            method.setAccessible(true);
+
+            // 브레이크 타임 경계 테스트
+            Map<ZonedDateTime, String> breakBoundaryTests = Map.of(
+                    // 브레이크 타임 시작 1분 전
+                    ZonedDateTime.of(2025, 5, 26, 11, 59, 0, 0, ZoneId.of("Asia/Seoul")), "영업 중",
+                    // 브레이크 타임 시작 정확히
+                    ZonedDateTime.of(2025, 5, 26, 12, 0, 0, 0, ZoneId.of("Asia/Seoul")), "브레이크 타임",
+                    // 브레이크 타임 중간
+                    ZonedDateTime.of(2025, 5, 26, 12, 30, 0, 0, ZoneId.of("Asia/Seoul")), "브레이크 타임",
+                    // 브레이크 타임 끝 1분 전
+                    ZonedDateTime.of(2025, 5, 26, 12, 59, 0, 0, ZoneId.of("Asia/Seoul")), "브레이크 타임",
+                    // 브레이크 타임 끝 정확히
+                    ZonedDateTime.of(2025, 5, 26, 13, 0, 0, 0, ZoneId.of("Asia/Seoul")), "영업 중"
+            );
+
+            for (Map.Entry<ZonedDateTime, String> test : breakBoundaryTests.entrySet()) {
+                ZonedDateTime time = test.getKey();
+                String expected = test.getValue();
+
+                try (MockedStatic<ZonedDateTime> mockNow = Mockito.mockStatic(ZonedDateTime.class)) {
+                    mockNow.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(time);
+
+                    // when
+                    String status = (String) method.invoke(placeQueryService, List.of(normalHours, breakHours));
+
+                    // then
+                    assertThat(status).as("시각 %s에서의 브레이크 타임 상태", time.toLocalTime())
+                            .isEqualTo(expected);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/dolpin/domain/place/service/query/PlaceDetailServiceTest.java
+++ b/src/test/java/com/dolpin/domain/place/service/query/PlaceDetailServiceTest.java
@@ -1,0 +1,111 @@
+package com.dolpin.domain.place.service.query;
+
+import com.dolpin.domain.place.dto.response.PlaceDetailResponse;
+import com.dolpin.domain.place.entity.*;
+import com.dolpin.domain.place.repository.PlaceRepository;
+import com.dolpin.global.exception.BusinessException;
+import com.dolpin.global.response.ResponseStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static com.dolpin.global.helper.PlaceTestHelper.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Place 상세 조회 서비스 테스트")
+class PlaceDetailServiceTest {
+
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @InjectMocks
+    private PlaceQueryServiceImpl placeQueryService;
+
+    @Nested
+    @DisplayName("getPlaceDetail 메서드 테스트")
+    class GetPlaceDetailTest {
+
+        @Test
+        @DisplayName("정상적인 장소 상세 조회가 동작한다")
+        void getPlaceDetail_WithValidId_ReturnsCompleteDetail() {
+            // given
+            Long placeId = 1L;
+            Place basicPlace = createMockPlaceForDetail(placeId, "테스트 카페", 37.5665, 126.9780);
+
+            // 키워드가 포함된 장소
+            Place placeWithKeywords = createMockPlaceWithKeywords(placeId, "테스트 카페", List.of("아늑한", "맛있는"));
+
+            // 메뉴가 포함된 장소
+            Place placeWithMenus = mock(Place.class);
+            PlaceMenu menu1 = createMockMenu("아메리카노", 4000);
+            PlaceMenu menu2 = createMockMenu("라떼", 4500);
+            given(placeWithMenus.getMenus()).willReturn(List.of(menu1, menu2));
+
+            // 영업시간이 포함된 장소
+            Place placeWithHours = mock(Place.class);
+            List<PlaceHours> hours = createCompleteBusinessHours();
+            given(placeWithHours.getHours()).willReturn(hours);
+
+            given(placeRepository.findBasicPlaceById(placeId)).willReturn(Optional.of(basicPlace));
+            given(placeRepository.findByIdWithKeywords(placeId)).willReturn(Optional.of(placeWithKeywords));
+            given(placeRepository.findByIdWithMenus(placeId)).willReturn(Optional.of(placeWithMenus));
+            given(placeRepository.findByIdWithHours(placeId)).willReturn(Optional.of(placeWithHours));
+
+            // when
+            PlaceDetailResponse result = placeQueryService.getPlaceDetail(placeId);
+
+            // then
+            assertThat(result.getId()).isEqualTo(placeId);
+            assertThat(result.getName()).isEqualTo("테스트 카페");
+            assertThat(result.getAddress()).isEqualTo("테스트 주소");
+            assertThat(result.getPhone()).isEqualTo("02-1234-5678");
+            assertThat(result.getDescription()).isEqualTo("테스트 설명");
+            assertThat(result.getThumbnail()).isEqualTo("test.jpg");
+
+            // 위치 정보 확인
+            assertThat(result.getLocation()).containsEntry("type", "Point");
+            double[] coordinates = (double[]) result.getLocation().get("coordinates");
+            assertThat(coordinates).containsExactly(126.9780, 37.5665);
+
+            // 키워드 확인
+            assertThat(result.getKeywords()).containsExactlyInAnyOrder("아늑한", "맛있는");
+
+            // 메뉴 확인
+            assertThat(result.getMenu()).hasSize(2);
+            assertThat(result.getMenu()).extracting(PlaceDetailResponse.Menu::getName)
+                    .containsExactlyInAnyOrder("아메리카노", "라떼");
+
+            // 영업시간 확인
+            assertThat(result.getOpeningHours()).isNotNull();
+            assertThat(result.getOpeningHours().getSchedules()).hasSize(7);
+
+            // 각 Repository 메서드가 호출되었는지 확인
+            verify(placeRepository).findBasicPlaceById(placeId);
+            verify(placeRepository).findByIdWithKeywords(placeId);
+            verify(placeRepository).findByIdWithMenus(placeId);
+            verify(placeRepository).findByIdWithHours(placeId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 장소 ID 조회 시 예외가 발생한다")
+        void getPlaceDetail_WithNonExistentId_ThrowsPlaceNotFoundException() {
+            // given
+            Long nonExistentId = 999L;
+            given(placeRepository.findBasicPlaceById(nonExistentId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> placeQueryService.getPlaceDetail(nonExistentId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("responseStatus")
+                    .isEqualTo(ResponseStatus.PLACE_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/com/dolpin/domain/place/service/query/PlaceQueryServiceImplTest.java
+++ b/src/test/java/com/dolpin/domain/place/service/query/PlaceQueryServiceImplTest.java
@@ -1,0 +1,60 @@
+package com.dolpin.domain.place.service.query;
+
+import com.dolpin.domain.place.client.PlaceAiClient;
+import com.dolpin.domain.place.dto.response.PlaceCategoryResponse;
+import com.dolpin.domain.place.repository.PlaceRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlaceQueryServiceImpl 통합 테스트")
+class PlaceQueryServiceImplTest {
+
+    @Mock private PlaceRepository placeRepository;
+    @Mock private PlaceAiClient placeAiClient;
+    @InjectMocks private PlaceQueryServiceImpl placeQueryService;
+
+    @Nested
+    @DisplayName("getAllCategories 메서드 테스트")
+    class GetAllCategoriesTest {
+
+        @Test
+        @DisplayName("카테고리 목록 정상 조회가 동작한다")
+        void getAllCategories_ReturnsAllAvailableCategories() {
+            // given
+            List<String> categories = Arrays.asList("카페", "식당", "술집", "베이커리", "패스트푸드");
+            given(placeRepository.findDistinctCategories()).willReturn(categories);
+
+            // when
+            PlaceCategoryResponse result = placeQueryService.getAllCategories();
+
+            // then
+            assertThat(result.getCategories()).hasSize(5);
+            assertThat(result.getCategories()).containsExactlyInAnyOrder(
+                    "카페", "식당", "술집", "베이커리", "패스트푸드");
+        }
+
+        @Test
+        @DisplayName("카테고리가 없을 때 빈 목록을 반환한다")
+        void getAllCategories_WithNoCategories_ReturnsEmptyList() {
+            // given
+            given(placeRepository.findDistinctCategories()).willReturn(Collections.emptyList());
+
+            // when
+            PlaceCategoryResponse result = placeQueryService.getAllCategories();
+
+            // then
+            assertThat(result.getCategories()).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/dolpin/domain/place/service/query/PlaceSearchServiceTest.java
+++ b/src/test/java/com/dolpin/domain/place/service/query/PlaceSearchServiceTest.java
@@ -1,0 +1,363 @@
+package com.dolpin.domain.place.service.query;
+
+import com.dolpin.domain.place.client.PlaceAiClient;
+import com.dolpin.domain.place.dto.response.*;
+import com.dolpin.domain.place.entity.*;
+import com.dolpin.domain.place.repository.PlaceRepository;
+import com.dolpin.global.exception.BusinessException;
+import com.dolpin.global.response.ResponseStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.locationtech.jts.geom.Coordinate;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.*;
+
+import static com.dolpin.global.helper.PlaceTestHelper.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Place 검색 서비스 테스트")
+class PlaceSearchServiceTest {
+
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @Mock
+    private PlaceAiClient placeAiClient;
+
+    @InjectMocks
+    private PlaceQueryServiceImpl placeQueryService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(placeQueryService, "defaultSearchRadius", DEFAULT_RADIUS);
+    }
+
+    @Nested
+    @DisplayName("searchPlaces 메서드 테스트")
+    class SearchPlacesTest {
+
+        @Test
+        @DisplayName("검색어만 있는 경우 AI 검색 로직이 정상 동작한다")
+        void searchPlaces_WithQueryOnly_PerformsAiSearch() {
+            // given
+            String query = "맛있는 파스타";
+            Double lat = 37.5665;
+            Double lng = 126.9780;
+
+            // AI 응답 설정
+            PlaceAiResponse.PlaceRecommendation rec1 = createRecommendation(1L, 0.95, List.of("맛있는", "이탈리안"));
+            PlaceAiResponse.PlaceRecommendation rec2 = createRecommendation(2L, 0.88, List.of("분위기좋은", "데이트"));
+            PlaceAiResponse aiResponse = new PlaceAiResponse(List.of(rec1, rec2));
+
+            given(placeAiClient.recommendPlaces(query)).willReturn(aiResponse);
+
+            // 거리 계산 결과
+            List<PlaceWithDistance> nearbyPlaces = List.of(
+                    createMockPlaceWithDistance(1L, "이탈리안 레스토랑", 37.5665, 126.9780, 150.0),
+                    createMockPlaceWithDistance(2L, "로맨틱 파스타", 37.5670, 126.9785, 300.0)
+            );
+            given(placeRepository.findPlacesWithinRadiusByIds(eq(List.of(1L, 2L)), eq(lat), eq(lng), eq(DEFAULT_RADIUS)))
+                    .willReturn(nearbyPlaces);
+
+            // 키워드 포함 장소 조회
+            List<Place> places = List.of(
+                    createMockPlace(1L, "이탈리안 레스토랑", 37.5665, 126.9780),
+                    createMockPlace(2L, "로맨틱 파스타", 37.5670, 126.9785)
+            );
+            given(placeRepository.findByIdsWithKeywords(eq(List.of(1L, 2L)))).willReturn(places);
+
+            // when
+            PlaceSearchResponse result = placeQueryService.searchPlaces(query, lat, lng, null);
+
+            // then
+            assertThat(result.getTotal()).isEqualTo(2);
+            assertThat(result.getPlaces()).hasSize(2);
+
+            // 유사도 점수 기준 정렬 확인 (높은 점수가 먼저)
+            PlaceSearchResponse.PlaceDto firstPlace = result.getPlaces().get(0);
+            PlaceSearchResponse.PlaceDto secondPlace = result.getPlaces().get(1);
+            assertThat(firstPlace.getSimilarityScore()).isGreaterThan(secondPlace.getSimilarityScore());
+            assertThat(firstPlace.getSimilarityScore()).isEqualTo(0.95);
+            assertThat(secondPlace.getSimilarityScore()).isEqualTo(0.88);
+
+            // AI 키워드 사용 확인
+            assertThat(firstPlace.getKeywords()).containsExactlyInAnyOrder("맛있는", "이탈리안");
+            assertThat(secondPlace.getKeywords()).containsExactlyInAnyOrder("분위기좋은", "데이트");
+
+            verify(placeAiClient).recommendPlaces(query);
+            verify(placeRepository).findPlacesWithinRadiusByIds(eq(List.of(1L, 2L)), eq(lat), eq(lng), eq(DEFAULT_RADIUS));
+            verify(placeRepository).findByIdsWithKeywords(eq(List.of(1L, 2L)));
+        }
+
+        @Test
+        @DisplayName("카테고리만 있는 경우 DB 직접 검색이 정상 동작한다")
+        void searchPlaces_WithCategoryOnly_PerformsDbSearch() {
+            // given
+            String category = "카페";
+            Double lat = 37.5665;
+            Double lng = 126.9780;
+
+            List<PlaceWithDistance> categoryPlaces = List.of(
+                    createMockPlaceWithDistance(1L, "스타벅스", 37.5665, 126.9780, 100.0),
+                    createMockPlaceWithDistance(2L, "투썸플레이스", 37.5670, 126.9785, 200.0)
+            );
+            given(placeRepository.findPlacesByCategoryWithinRadius(category, lat, lng, DEFAULT_RADIUS))
+                    .willReturn(categoryPlaces);
+
+            // 키워드 포함 장소들 (ID 명시적 설정)
+            Place place1 = mock(Place.class);
+            given(place1.getId()).willReturn(1L);
+            List<PlaceKeyword> keywords1 = List.of("체인점", "넓은").stream().map(kw -> {
+                Keyword keyword = mock(Keyword.class);
+                given(keyword.getKeyword()).willReturn(kw);
+                PlaceKeyword placeKeyword = mock(PlaceKeyword.class);
+                given(placeKeyword.getKeyword()).willReturn(keyword);
+                return placeKeyword;
+            }).toList();
+            given(place1.getKeywords()).willReturn(keywords1);
+
+            Place place2 = mock(Place.class);
+            given(place2.getId()).willReturn(2L);
+            List<PlaceKeyword> keywords2 = List.of("디저트", "케이크").stream().map(kw -> {
+                Keyword keyword = mock(Keyword.class);
+                given(keyword.getKeyword()).willReturn(kw);
+                PlaceKeyword placeKeyword = mock(PlaceKeyword.class);
+                given(placeKeyword.getKeyword()).willReturn(keyword);
+                return placeKeyword;
+            }).toList();
+            given(place2.getKeywords()).willReturn(keywords2);
+
+            List<Place> places = List.of(place1, place2);
+            given(placeRepository.findByIdsWithKeywords(eq(List.of(1L, 2L)))).willReturn(places);
+
+            // when
+            PlaceSearchResponse result = placeQueryService.searchPlaces(null, lat, lng, category);
+
+            // then
+            assertThat(result.getTotal()).isEqualTo(2);
+            assertThat(result.getPlaces()).hasSize(2);
+
+            // 카테고리 검색은 유사도 점수가 null
+            assertThat(result.getPlaces().get(0).getSimilarityScore()).isNull();
+            assertThat(result.getPlaces().get(1).getSimilarityScore()).isNull();
+
+            // DB 키워드 사용 확인
+            assertThat(result.getPlaces().get(0).getKeywords()).containsExactlyInAnyOrder("체인점", "넓은");
+
+            verify(placeRepository).findPlacesByCategoryWithinRadius(category, lat, lng, DEFAULT_RADIUS);
+            verify(placeRepository).findByIdsWithKeywords(eq(List.of(1L, 2L)));
+            verifyNoInteractions(placeAiClient);
+        }
+
+        @Test
+        @DisplayName("검색어와 카테고리 동시 입력 시 예외가 발생한다")
+        void searchPlaces_WithBothQueryAndCategory_ThrowsException() {
+            // given
+            String query = "맛있는 카페";
+            String category = "카페";
+            Double lat = 37.5665;
+            Double lng = 126.9780;
+
+            // when & then
+            assertThatThrownBy(() -> placeQueryService.searchPlaces(query, lat, lng, category))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("검색어와 카테고리 중 하나만 선택해주세요")
+                    .extracting("responseStatus")
+                    .isEqualTo(ResponseStatus.INVALID_PARAMETER);
+        }
+
+        @Test
+        @DisplayName("검색어와 카테고리 모두 없을 때 예외가 발생한다")
+        void searchPlaces_WithNeitherQueryNorCategory_ThrowsException() {
+            // given
+            Double lat = 37.5665;
+            Double lng = 126.9780;
+
+            // when & then
+            assertThatThrownBy(() -> placeQueryService.searchPlaces(null, lat, lng, null))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("검색어 또는 카테고리가 필요합니다");
+
+            assertThatThrownBy(() -> placeQueryService.searchPlaces("", lat, lng, ""))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("검색어 또는 카테고리가 필요합니다");
+
+            assertThatThrownBy(() -> placeQueryService.searchPlaces("   ", lat, lng, "   "))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("검색어 또는 카테고리가 필요합니다");
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "맛있는 카페, ,",
+                "맛있는 카페, 37.5665,",
+                "맛있는 카페, , 126.9780"
+        })
+        @DisplayName("위치 정보(lat, lng) 누락 시 예외가 발생한다")
+        void searchPlaces_WithMissingLocation_ThrowsException(String query, Double lat, Double lng) {
+            // when & then
+            assertThatThrownBy(() -> placeQueryService.searchPlaces(query, lat, lng, null))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("위치 정보가 필요합니다");
+        }
+
+        @Test
+        @DisplayName("AI 서비스 응답이 null일 때 빈 결과를 반환한다")
+        void searchPlaces_WithNullAiResponse_ReturnsEmptyResult() {
+            // given
+            String query = "존재하지 않는 검색어";
+            Double lat = 37.5665;
+            Double lng = 126.9780;
+
+            given(placeAiClient.recommendPlaces(query)).willReturn(null);
+
+            // when
+            PlaceSearchResponse result = placeQueryService.searchPlaces(query, lat, lng, null);
+
+            // then
+            assertThat(result.getTotal()).isEqualTo(0);
+            assertThat(result.getPlaces()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("AI 서비스 응답이 빈 결과일 때 빈 결과를 반환한다")
+        void searchPlaces_WithEmptyAiResponse_ReturnsEmptyResult() {
+            // given
+            String query = "존재하지 않는 검색어";
+            Double lat = 37.5665;
+            Double lng = 126.9780;
+
+            PlaceAiResponse emptyResponse = new PlaceAiResponse(Collections.emptyList());
+            given(placeAiClient.recommendPlaces(query)).willReturn(emptyResponse);
+
+            // when
+            PlaceSearchResponse result = placeQueryService.searchPlaces(query, lat, lng, null);
+
+            // then
+            assertThat(result.getTotal()).isEqualTo(0);
+            assertThat(result.getPlaces()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("반경 내 장소가 없을 때 빈 결과를 반환한다")
+        void searchPlaces_WithNoPlacesInRadius_ReturnsEmptyResult() {
+            // given
+            String query = "맛있는 카페";
+            Double lat = 37.5665;
+            Double lng = 126.9780;
+
+            PlaceAiResponse.PlaceRecommendation rec = createRecommendation(1L, 0.95, List.of("맛있는"));
+            PlaceAiResponse aiResponse = new PlaceAiResponse(List.of(rec));
+            given(placeAiClient.recommendPlaces(query)).willReturn(aiResponse);
+
+            // 반경 내 장소 없음
+            given(placeRepository.findPlacesWithinRadiusByIds(eq(List.of(1L)), eq(lat), eq(lng), eq(DEFAULT_RADIUS)))
+                    .willReturn(Collections.emptyList());
+
+            // when
+            PlaceSearchResponse result = placeQueryService.searchPlaces(query, lat, lng, null);
+
+            // then
+            assertThat(result.getTotal()).isEqualTo(0);
+            assertThat(result.getPlaces()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("유사도 점수 기준 정렬이 정상 동작한다")
+        void searchPlaces_SortsBySimilarityScore() {
+            // given
+            String query = "카페";
+            Double lat = 37.5665;
+            Double lng = 126.9780;
+
+            // 유사도 점수가 다른 추천 결과 (의도적으로 순서를 섞음)
+            PlaceAiResponse aiResponse = new PlaceAiResponse(List.of(
+                    createRecommendation(1L, 0.75, List.of("평범한")),
+                    createRecommendation(2L, 0.95, List.of("최고")),
+                    createRecommendation(3L, 0.88, List.of("좋은"))
+            ));
+            given(placeAiClient.recommendPlaces(query)).willReturn(aiResponse);
+
+            List<PlaceWithDistance> nearbyPlaces = List.of(
+                    createMockPlaceWithDistance(1L, "평범한 카페", 37.5665, 126.9780, 100.0),
+                    createMockPlaceWithDistance(2L, "최고의 카페", 37.5666, 126.9781, 200.0),
+                    createMockPlaceWithDistance(3L, "좋은 카페", 37.5667, 126.9782, 300.0)
+            );
+            given(placeRepository.findPlacesWithinRadiusByIds(eq(List.of(1L, 2L, 3L)), eq(lat), eq(lng), eq(DEFAULT_RADIUS)))
+                    .willReturn(nearbyPlaces);
+
+            // Place 객체들을 개별적으로 생성 (ID와 location 명시적 설정)
+            Place place1 = mock(Place.class);
+            given(place1.getId()).willReturn(1L);
+            given(place1.getName()).willReturn("평범한 카페");
+            given(place1.getLocation()).willReturn(GEOMETRY_FACTORY.createPoint(new Coordinate(126.9780, 37.5665)));
+            List<PlaceKeyword> keywords1 = List.of("평범한").stream().map(kw -> {
+                Keyword keyword = mock(Keyword.class);
+                given(keyword.getKeyword()).willReturn(kw);
+                PlaceKeyword placeKeyword = mock(PlaceKeyword.class);
+                given(placeKeyword.getKeyword()).willReturn(keyword);
+                return placeKeyword;
+            }).toList();
+            given(place1.getKeywords()).willReturn(keywords1);
+
+            Place place2 = mock(Place.class);
+            given(place2.getId()).willReturn(2L);
+            given(place2.getName()).willReturn("최고의 카페");
+            given(place2.getLocation()).willReturn(GEOMETRY_FACTORY.createPoint(new Coordinate(126.9781, 37.5666)));
+            List<PlaceKeyword> keywords2 = List.of("최고").stream().map(kw -> {
+                Keyword keyword = mock(Keyword.class);
+                given(keyword.getKeyword()).willReturn(kw);
+                PlaceKeyword placeKeyword = mock(PlaceKeyword.class);
+                given(placeKeyword.getKeyword()).willReturn(keyword);
+                return placeKeyword;
+            }).toList();
+            given(place2.getKeywords()).willReturn(keywords2);
+
+            Place place3 = mock(Place.class);
+            given(place3.getId()).willReturn(3L);
+            given(place3.getName()).willReturn("좋은 카페");
+            given(place3.getLocation()).willReturn(GEOMETRY_FACTORY.createPoint(new Coordinate(126.9782, 37.5667)));
+            List<PlaceKeyword> keywords3 = List.of("좋은").stream().map(kw -> {
+                Keyword keyword = mock(Keyword.class);
+                given(keyword.getKeyword()).willReturn(kw);
+                PlaceKeyword placeKeyword = mock(PlaceKeyword.class);
+                given(placeKeyword.getKeyword()).willReturn(keyword);
+                return placeKeyword;
+            }).toList();
+            given(place3.getKeywords()).willReturn(keywords3);
+
+            List<Place> places = List.of(place1, place2, place3);
+            given(placeRepository.findByIdsWithKeywords(eq(List.of(1L, 2L, 3L)))).willReturn(places);
+
+            // when
+            PlaceSearchResponse result = placeQueryService.searchPlaces(query, lat, lng, null);
+
+            // then
+            assertThat(result.getPlaces()).hasSize(3);
+
+            // 유사도 점수 순으로 정렬되어야 함 (0.95 > 0.88 > 0.75)
+            List<Double> scores = result.getPlaces().stream()
+                    .map(PlaceSearchResponse.PlaceDto::getSimilarityScore)
+                    .toList();
+            assertThat(scores).containsExactly(0.95, 0.88, 0.75);
+
+            // 해당하는 장소 이름도 확인
+            List<String> names = result.getPlaces().stream()
+                    .map(PlaceSearchResponse.PlaceDto::getName)
+                    .toList();
+            assertThat(names).containsExactly("최고의 카페", "좋은 카페", "평범한 카페");
+        }
+    }
+}

--- a/src/test/java/com/dolpin/global/config/TestConfig.java
+++ b/src/test/java/com/dolpin/global/config/TestConfig.java
@@ -1,4 +1,4 @@
-package com.dolpin;
+package com.dolpin.global.config;
 
 import com.dolpin.global.storage.dto.request.PresignedUrlRequest;
 import com.dolpin.global.storage.dto.reseponse.PresignedUrlResponse;

--- a/src/test/java/com/dolpin/global/fixture/PlaceFixture.java
+++ b/src/test/java/com/dolpin/global/fixture/PlaceFixture.java
@@ -1,0 +1,123 @@
+package com.dolpin.global.fixture;
+
+import com.dolpin.domain.place.entity.*;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+public class PlaceFixture {
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+
+    // SQL을 사용한 Place 생성
+    public static Long createAndPersistPlace(TestEntityManager entityManager, String name, double lat, double lng) {
+        entityManager.getEntityManager().createNativeQuery("""
+            INSERT INTO place (name, location, road_address, category, image_url, description, phone, created_at, updated_at)
+            VALUES (?1, ST_SetSRID(ST_Point(?2, ?3), 4326), ?4, ?5, ?6, ?7, ?8, NOW(), NOW())
+            """)
+                .setParameter(1, name)
+                .setParameter(2, lng)
+                .setParameter(3, lat)
+                .setParameter(4, "테스트 주소")
+                .setParameter(5, "카페")
+                .setParameter(6, "test.jpg")
+                .setParameter(7, "테스트 설명")
+                .setParameter(8, "02-1234-5678")
+                .executeUpdate();
+
+        entityManager.flush();
+
+        // 생성된 ID 반환
+        return (Long) entityManager.getEntityManager()
+                .createNativeQuery("SELECT id FROM place WHERE name = ? ORDER BY id DESC LIMIT 1")
+                .setParameter(1, name)
+                .getSingleResult();
+    }
+
+    public static Long createPlaceWithCategory(TestEntityManager entityManager, String name, String category, double lat, double lng) {
+        entityManager.getEntityManager().createNativeQuery("""
+           INSERT INTO place (name, location, road_address, category, image_url, description, phone, created_at, updated_at)
+            VALUES (?1, ST_SetSRID(ST_Point(?2, ?3), 4326), ?4, ?5, ?6, ?7, ?8, NOW(), NOW())
+            """)
+                .setParameter(1, name)
+                .setParameter(2, lng)
+                .setParameter(3, lat)
+                .setParameter(4, "테스트 주소")
+                .setParameter(5, category)
+                .setParameter(6, "test.jpg")
+                .setParameter(7, "테스트 설명")
+                .setParameter(8, "02-1234-5678")
+                .executeUpdate();
+
+        entityManager.flush();
+
+        return (Long) entityManager.getEntityManager()
+                .createNativeQuery("SELECT id FROM place WHERE name = ? AND category = ? ORDER BY id DESC LIMIT 1")
+                .setParameter(1, name)
+                .setParameter(2, category)
+                .getSingleResult();
+    }
+
+    public static PlaceHours createAndPersistPlaceHours(TestEntityManager entityManager, Long placeId, String dayOfWeek, String openTime, String closeTime) {
+        PlaceHours placeHours = PlaceHours.builder()
+                .dayOfWeek(dayOfWeek)
+                .openTime(openTime)
+                .closeTime(closeTime)
+                .isBreakTime(false)
+                .build();
+
+        // Place 엔티티 참조를 위해 먼저 Place를 조회
+        Place place = entityManager.find(Place.class, placeId);
+
+        // 리플렉션으로 place 설정
+        try {
+            var field = PlaceHours.class.getDeclaredField("place");
+            field.setAccessible(true);
+            field.set(placeHours, place);
+        } catch (Exception e) {
+            throw new RuntimeException("PlaceHours 생성 실패", e);
+        }
+
+        return entityManager.persistAndFlush(placeHours);
+    }
+
+    public static PlaceMenu createAndPersistPlaceMenu(TestEntityManager entityManager, Long placeId, String menuName, Integer price) {
+        PlaceMenu placeMenu = PlaceMenu.builder()
+                .menuName(menuName)
+                .price(price)
+                .build();
+
+        Place place = entityManager.find(Place.class, placeId);
+
+        try {
+            var field = PlaceMenu.class.getDeclaredField("place");
+            field.setAccessible(true);
+            field.set(placeMenu, place);
+        } catch (Exception e) {
+            throw new RuntimeException("PlaceMenu 생성 실패", e);
+        }
+
+        return entityManager.persistAndFlush(placeMenu);
+    }
+
+    public static Keyword createAndPersistKeyword(TestEntityManager entityManager, String keyword) {
+        Keyword keywordEntity = Keyword.builder()
+                .keyword(keyword)
+                .build();
+        return entityManager.persistAndFlush(keywordEntity);
+    }
+
+    public static PlaceKeyword createAndPersistPlaceKeyword(TestEntityManager entityManager, Long placeId, Long keywordId) {
+        Place place = entityManager.find(Place.class, placeId);
+        Keyword keyword = entityManager.find(Keyword.class, keywordId);
+
+        PlaceKeyword placeKeyword = PlaceKeyword.builder()
+                .place(place)
+                .keyword(keyword)
+                .build();
+
+        return entityManager.persistAndFlush(placeKeyword);
+    }
+}

--- a/src/test/java/com/dolpin/global/helper/PlaceTestHelper.java
+++ b/src/test/java/com/dolpin/global/helper/PlaceTestHelper.java
@@ -1,0 +1,135 @@
+package com.dolpin.global.helper;
+
+import com.dolpin.domain.place.dto.response.*;
+import com.dolpin.domain.place.entity.*;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.*;
+
+import static org.mockito.BDDMockito.*;
+
+public class PlaceTestHelper {
+
+    public static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+    public static final double DEFAULT_RADIUS = 1000.0;
+
+    // AI 응답 관련
+    public static PlaceAiResponse.PlaceRecommendation createRecommendation(Long id, Double score, List<String> keywords) {
+        PlaceAiResponse.PlaceRecommendation recommendation = new PlaceAiResponse.PlaceRecommendation();
+        ReflectionTestUtils.setField(recommendation, "id", id);
+        ReflectionTestUtils.setField(recommendation, "similarityScore", score);
+        ReflectionTestUtils.setField(recommendation, "keyword", keywords);
+        return recommendation;
+    }
+
+    // PlaceWithDistance Mock 생성
+    public static PlaceWithDistance createMockPlaceWithDistance(Long id, String name, double lat, double lng, double distance) {
+        return new PlaceWithDistance() {
+            @Override public Long getId() { return id; }
+            @Override public String getName() { return name; }
+            @Override public String getCategory() { return "카페"; }
+            @Override public String getRoadAddress() { return "테스트 주소"; }
+            @Override public String getLotAddress() { return "테스트 지번"; }
+            @Override public Double getDistance() { return distance; }
+            @Override public Double getLongitude() { return lng; }
+            @Override public Double getLatitude() { return lat; }
+            @Override public String getImageUrl() { return "test.jpg"; }
+        };
+    }
+
+    // Place Mock 생성
+    public static Place createMockPlace(Long id, String name, double lat, double lng) {
+        Point location = GEOMETRY_FACTORY.createPoint(new Coordinate(lng, lat));
+        Place place = mock(Place.class);
+        given(place.getId()).willReturn(id);
+        given(place.getName()).willReturn(name);
+        given(place.getLocation()).willReturn(location);
+        given(place.getKeywords()).willReturn(Collections.emptyList());
+        return place;
+    }
+
+    public static Place createMockPlaceForDetail(Long id, String name, double lat, double lng) {
+        Point location = GEOMETRY_FACTORY.createPoint(new Coordinate(lng, lat));
+        Place place = mock(Place.class);
+        given(place.getId()).willReturn(id);
+        given(place.getName()).willReturn(name);
+        given(place.getLocation()).willReturn(location);
+        given(place.getRoadAddress()).willReturn("테스트 주소");
+        given(place.getImageUrl()).willReturn("test.jpg");
+        given(place.getDescription()).willReturn("테스트 설명");
+        given(place.getPhone()).willReturn("02-1234-5678");
+        return place;
+    }
+
+    // 키워드가 포함된 Place Mock 생성
+    public static Place createMockPlaceWithKeywords(Long id, String name, List<String> keywordStrings) {
+        Place place = mock(Place.class);
+
+        List<PlaceKeyword> keywords = keywordStrings.stream()
+                .map(kw -> {
+                    Keyword keyword = mock(Keyword.class);
+                    given(keyword.getKeyword()).willReturn(kw);
+                    PlaceKeyword placeKeyword = mock(PlaceKeyword.class);
+                    given(placeKeyword.getKeyword()).willReturn(keyword);
+                    return placeKeyword;
+                })
+                .toList();
+        given(place.getKeywords()).willReturn(keywords);
+        return place;
+    }
+    // PlaceMenu Mock 생성
+    public static PlaceMenu createMockMenu(String name, Integer price) {
+        PlaceMenu menu = mock(PlaceMenu.class);
+        given(menu.getMenuName()).willReturn(name);
+        given(menu.getPrice()).willReturn(price);
+        return menu;
+    }
+
+    // PlaceHours Mock 생성
+    public static PlaceHours createMockHours(String day, String openTime, String closeTime, Boolean isBreakTime) {
+        PlaceHours hours = mock(PlaceHours.class);
+        given(hours.getDayOfWeek()).willReturn(day);
+        given(hours.getOpenTime()).willReturn(openTime);
+        given(hours.getCloseTime()).willReturn(closeTime);
+        given(hours.getIsBreakTime()).willReturn(isBreakTime);
+        return hours;
+    }
+
+    // 복잡한 영업시간 생성 헬퍼
+    public static List<PlaceHours> createCompleteBusinessHours() {
+        List<PlaceHours> hours = new ArrayList<>();
+
+        // 월요일 - 영업시간
+        PlaceHours monOpen = mock(PlaceHours.class);
+        given(monOpen.getDayOfWeek()).willReturn("월");
+        given(monOpen.getOpenTime()).willReturn("09:00");
+        given(monOpen.getCloseTime()).willReturn("21:00");
+        given(monOpen.getIsBreakTime()).willReturn(false);
+        hours.add(monOpen);
+
+        // 월요일 - 브레이크타임
+        PlaceHours monBreak = mock(PlaceHours.class);
+        given(monBreak.getDayOfWeek()).willReturn("월");
+        given(monBreak.getOpenTime()).willReturn("15:00");
+        given(monBreak.getCloseTime()).willReturn("16:00");
+        given(monBreak.getIsBreakTime()).willReturn(true);
+        hours.add(monBreak);
+
+        // 화요일~토요일 기본 영업
+        String[] days = {"화", "수", "목", "금", "토"};
+        for (String day : days) {
+            PlaceHours dayHours = mock(PlaceHours.class);
+            given(dayHours.getDayOfWeek()).willReturn(day);
+            given(dayHours.getOpenTime()).willReturn("09:00");
+            given(dayHours.getCloseTime()).willReturn("21:00");
+            given(dayHours.getIsBreakTime()).willReturn(false);
+            hours.add(dayHours);
+        }
+
+        return hours;
+    }
+}

--- a/src/test/resources/init-postgis.sql
+++ b/src/test/resources/init-postgis.sql
@@ -1,3 +1,0 @@
--- PostGIS 확장 설치
-CREATE EXTENSION IF NOT EXISTS postgis;
-CREATE EXTENSION IF NOT EXISTS postgis_topology;


### PR DESCRIPTION
## 📝 PR 개요

<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->

PlaceQueryService 테스트 코드 리팩토링 및 포괄적 테스트 커버리지 확장

## 🔍 변경사항

 <!-- 주요 변경사항 목록 (불릿 포인트) -->

- PlaceTestHelper: 테스트 코드 재사용성을 위한 헬퍼 클래스 추가
    - Place, PlaceWithDistance, PlaceMenu, PlaceHours Mock 객체 생성 유틸리티
    - AI 응답 및 복잡한 영업시간 생성 헬퍼 메서드
    - 테스트 클래스 간 중복 코드 제거 및 Mock 설정 표준화

- PlaceSearchServiceTest: 장소 검색 기능 전용 테스트 클래스 분리
    - AI 기반 검색 로직 테스트 (유사도 점수, 키워드 매핑)
    - 카테고리 기반 DB 직접 검색 테스트
    - 검색 파라미터 유효성 검증 (동시 입력, 위치 정보 누락)
    - 엣지 케이스 처리 (빈 AI 응답, 반경 내 장소 없음)
    - 유사도 점수 기준 정렬 알고리즘 검증

- PlaceDetailServiceTest: 장소 상세 조회 기능 전용 테스트 클래스 분리
    - 완전한 장소 상세 정보 조회 테스트 (키워드, 메뉴, 영업시간)
    - 존재하지 않는 장소 예외 처리 테스트
    - 위치 좌표 변환 및 응답 구조 검증

- BusinessHoursUtilTest: 영업시간 로직 및 Private 메서드 테스트 분리
    - 거리 포맷팅 유틸리티 테스트 (m/km 단위 변환)
    - 시간 파싱 및 분 단위 변환 테스트
    - 영업 상태 판단 로직 테스트 (영업 중, 영업 종료, 브레이크 타임)
    - 복잡한 엣지 케이스 테스트 (24시간 운영, 자정 넘김, 경계 시간)
    - 요일별 스케줄 구성 로직 검증

- PlaceQueryServiceImplTest: 메인 통합 테스트로 축소
    - 카테고리 목록 조회 기능 테스트
    - 빈 카테고리 처리 테스트
    - 핵심 통합 테스트 역할로 단순화

## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->

Closes #162 

## 🧪 테스트 (Optional)

<!-- 테스트 방법 및 결과 -->

- [x] 영업시간 및 유틸리티 테스트(25개 케이스)
- [x] 상세 조회 테스트(2개 케이스)
- [x] 통합 테스트(2개 케이스)
- [x] 검색 기능 테스트(11개 케이스)
