### PR TITLE
Feat : 대댓글 기능 추가

### DIFF
--- a/src/main/java/com/dolpin/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/dolpin/domain/comment/dto/request/CommentCreateRequest.java
@@ -14,4 +14,6 @@ public class CommentCreateRequest {
     @NotBlank(message = "댓글 내용은 필수입니다")
     @Size(max = 1000, message = "댓글은 1000자 이내여야 합니다")
     private String content;
+
+    private Long parentCommentId;
 }

--- a/src/main/java/com/dolpin/domain/comment/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/dolpin/domain/comment/dto/response/CommentCreateResponse.java
@@ -18,6 +18,8 @@ public class CommentCreateResponse {
     private Long id;
     private UserDto user;
     private String content;
+    private Integer depth;
+    private Long parentCommentId;
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
     private LocalDateTime createdAt;
@@ -48,6 +50,8 @@ public class CommentCreateResponse {
                 .id(comment.getId())
                 .user(UserDto.from(user))
                 .content(comment.getContent())
+                .depth(comment.getDepth())
+                .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
                 .createdAt(comment.getCreatedAt())
                 .isOwner(isOwner)
                 .momentId(comment.getMomentId())

--- a/src/main/java/com/dolpin/domain/comment/dto/response/CommentListResponse.java
+++ b/src/main/java/com/dolpin/domain/comment/dto/response/CommentListResponse.java
@@ -30,6 +30,8 @@ public class CommentListResponse {
         private Long id;
         private UserDto user;
         private String content;
+        private Integer depth;
+        private Long parentCommentId;
 
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
         private LocalDateTime createdAt;

--- a/src/main/java/com/dolpin/domain/comment/entity/Comment.java
+++ b/src/main/java/com/dolpin/domain/comment/entity/Comment.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "comment")
@@ -26,6 +28,14 @@ public class Comment {
     @Column(nullable = false, length = 1000)
     private String content;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @Column(name = "depth", nullable = false)
+    @Builder.Default
+    private Integer depth = 0;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -47,13 +57,6 @@ public class Comment {
         this.updatedAt = LocalDateTime.now();
     }
 
-    // 비즈니스 메서드
-    public void updateContent(String content) {
-        if (content != null && !content.trim().isEmpty()) {
-            this.content = content;
-        }
-    }
-
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
     }
@@ -72,5 +75,9 @@ public class Comment {
 
     public boolean canBeDeletedBy(Long userId) {
         return !isDeleted() && isOwnedBy(userId);
+    }
+
+    public boolean isReply() {
+        return this.parentComment != null;
     }
 }

--- a/src/main/java/com/dolpin/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/dolpin/domain/comment/repository/CommentRepository.java
@@ -15,19 +15,24 @@ import java.util.Optional;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    // 특정 기록의 댓글 목록 조회 (첫 페이지용)
+    // 전체 댓글 조회
     @Query("SELECT c FROM Comment c " +
             "WHERE c.momentId = :momentId " +
             "AND c.deletedAt IS NULL " +
-            "ORDER BY c.createdAt ASC")
+            "ORDER BY " +
+            "CASE WHEN c.parentComment IS NULL THEN c.createdAt END ASC, " +
+            "c.parentComment.createdAt ASC, " +
+            "c.createdAt ASC")
     Page<Comment> findByMomentIdAndNotDeleted(@Param("momentId") Long momentId, Pageable pageable);
 
-    // 네이티브 쿼리로 커서 기반 페이지네이션
+    // 전체 댓글 조회 - 커서 기반 페이지네이션
     @Query(value = "SELECT * FROM comment c " +
             "WHERE c.moment_id = :momentId " +
             "AND c.deleted_at IS NULL " +
             "AND (:cursor IS NULL OR c.created_at > CAST(:cursor AS timestamp)) " +
-            "ORDER BY c.created_at ASC " +
+            "ORDER BY " +
+            "CASE WHEN c.parent_comment_id IS NULL THEN c.created_at END ASC, " +
+            "c.created_at ASC " +
             "LIMIT :limit",
             nativeQuery = true)
     List<Comment> findByMomentIdAndNotDeletedWithCursorNative(
@@ -35,19 +40,13 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             @Param("cursor") String cursor,
             @Param("limit") int limit);
 
-    // 특정 기록의 댓글 개수
-    @Query("SELECT COUNT(c) FROM Comment c " +
-            "WHERE c.momentId = :momentId " +
+    // 부모 댓글 유효성 검사
+    @Query("SELECT c FROM Comment c " +
+            "WHERE c.id = :commentId " +
+            "AND c.momentId = :momentId " +
             "AND c.deletedAt IS NULL")
-    long countByMomentIdAndNotDeleted(@Param("momentId") Long momentId);
+    Optional<Comment> findValidParentComment(@Param("commentId") Long commentId, @Param("momentId") Long momentId);
 
-    // 특정 사용자의 댓글 개수
-    @Query("SELECT COUNT(c) FROM Comment c " +
-            "WHERE c.userId = :userId " +
-            "AND c.deletedAt IS NULL")
-    long countByUserIdAndNotDeleted(@Param("userId") Long userId);
-
-    // 댓글 ID와 기록 ID로 댓글 조회
     @Query("SELECT c FROM Comment c " +
             "WHERE c.id = :commentId " +
             "AND c.momentId = :momentId " +
@@ -56,14 +55,11 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             @Param("commentId") Long commentId,
             @Param("momentId") Long momentId);
 
-    // 사용자가 작성한 댓글 목록
-    @Query("SELECT c FROM Comment c " +
-            "WHERE c.userId = :userId " +
-            "AND c.deletedAt IS NULL " +
-            "ORDER BY c.createdAt DESC")
-    Page<Comment> findByUserIdAndNotDeleted(@Param("userId") Long userId, Pageable pageable);
+    @Query("SELECT COUNT(c) FROM Comment c " +
+            "WHERE c.momentId = :momentId " +
+            "AND c.deletedAt IS NULL")
+    long countByMomentIdAndNotDeleted(@Param("momentId") Long momentId);
 
-    // 여러 기록 댓글 갯수 조회
     @Query("SELECT c.momentId, COUNT(c) FROM Comment c " +
             "WHERE c.momentId IN :momentIds " +
             "AND c.deletedAt IS NULL " +

--- a/src/main/java/com/dolpin/domain/comment/service/query/CommentQueryServiceImpl.java
+++ b/src/main/java/com/dolpin/domain/comment/service/query/CommentQueryServiceImpl.java
@@ -129,6 +129,8 @@ public class CommentQueryServiceImpl implements CommentQueryService {
                         .profileImage(user.getImageUrl())
                         .build())
                 .content(comment.getContent())
+                .depth(comment.getDepth())
+                .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
                 .createdAt(comment.getCreatedAt())
                 .isOwner(comment.isOwnedBy(currentUserId))
                 .build();

--- a/src/main/java/com/dolpin/domain/comment/service/query/CommentQueryServiceImpl.java
+++ b/src/main/java/com/dolpin/domain/comment/service/query/CommentQueryServiceImpl.java
@@ -42,18 +42,16 @@ public class CommentQueryServiceImpl implements CommentQueryService {
         Moment moment = validateMomentAccess(momentId, currentUserId);
 
         int pageSize = validateAndGetLimit(limit);
-        String cursorString = cursor; // String 그대로 사용
         int queryLimit = pageSize + 1; // hasNext 판단용
 
         List<Comment> comments;
 
-        if (cursorString != null && !cursorString.trim().isEmpty()) {
+        if (cursor != null && !cursor.trim().isEmpty()) {
             // 커서 기반 페이지네이션 (네이티브 쿼리)
-            comments = commentRepository.findByMomentIdAndNotDeletedWithCursorNative(momentId, cursorString, queryLimit);
+            comments = commentRepository.findByMomentIdAndNotDeletedWithCursorNative(momentId, cursor, queryLimit);
         } else {
-            // 첫 페이지 조회 (기존 JPQL 쿼리 사용)
-            Pageable pageable = PageRequest.of(0, queryLimit);
-            comments = commentRepository.findByMomentIdAndNotDeleted(momentId, pageable).getContent();
+            // 첫 페이지 조회 - 스레드 정렬 사용
+            comments = commentRepository.findByMomentIdAndNotDeletedWithPagination(momentId, queryLimit, 0);
         }
 
         return buildCommentListResponse(comments, pageSize, currentUserId, momentId);


### PR DESCRIPTION
## 📝 PR 개요
댓글에 대댓글(nested reply) 기능을 추가하여 사용자들이 특정 댓글에 대해 더 구체적으로 소통할 수 있도록 개선. 기존 시간순 정렬 방식에서 스레드 기반 정렬로 변경하여 원댓글과 대댓글이 함께 표시되도록 구현.

## 🔍 변경사항
- Comment 엔티티 확장: `parentComment`, `depth` 필드 추가로 댓글 계층 구조 지원
- 스레드 기반 정렬 시스템: 원댓글과 대댓글이 함께 그룹핑되어 표시되도록 쿼리 개선
- 대댓글 생성 API: 부모 댓글 유효성 검증 및 대댓글 생성 로직 구현
- 페이지네이션 개선: 커서 기반 페이지네이션에서 스레드 구조 유지
- API 응답 확장: `depth`, `parent_comment_id` 필드 추가로 프론트엔드에서 계층 구조 렌더링 지원
- 데이터베이스 스키마 업데이트: `parent_comment_id`, `depth` 컬럼 추가

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
Closes #230
